### PR TITLE
Add json validation schemas to backend repo

### DIFF
--- a/data/schemas/validate_eventsGet.json
+++ b/data/schemas/validate_eventsGet.json
@@ -1,0 +1,29 @@
+{
+	"definitions": {},
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "https://example.com/object1688897907.json",
+	"title": "Root",
+	"type": "object",
+	"required": [
+		"event",
+		"data"
+	],
+	"properties": {
+		"event": {
+			"$id": "#root/event",
+			"title": "Event",
+			"type": "string",
+			"default": "",
+			"examples": [
+				"mac:vote_event"
+			],
+			"pattern": "^.*$"
+		},
+		"data": {
+			"$id": "#root/data",
+			"title": "Data",
+			"type": "object"
+		}
+
+	}
+}

--- a/data/schemas/validate_gameResponse.json
+++ b/data/schemas/validate_gameResponse.json
@@ -1,0 +1,121 @@
+{
+	"definitions": {},
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "https://example.com/object1688894919.json",
+	"title": "Root",
+	"type": "object",
+	"required": [
+		"players",
+		"map",
+		"ip",
+		"hostname",
+		"maxPlayers",
+		"numPlayers",
+		"gamemode"
+	],
+	"properties": {
+		"players": {
+			"$id": "#root/players",
+			"title": "Players",
+			"type": "array",
+			"default": [],
+			"items": {
+				"$ref": "validate_playerResponse.json"
+            }
+
+		},
+		"map": {
+			"$id": "#root/map",
+			"title": "Map",
+			"type": "string",
+			"default": "",
+			"examples": [
+				"ctf_2fort"
+			],
+			"pattern": "^.+$"
+		},
+		"ip": {
+			"$id": "#root/ip",
+			"title": "Ip",
+			"type": "string",
+			"default": "",
+			"examples": [
+				"127.0.0.1"
+			],
+			"pattern": "^.+$"
+		},
+		"hostname": {
+			"$id": "#root/hostname",
+			"title": "Hostname",
+			"type": "string",
+			"default": "",
+			"examples": [
+				"Uncletopia Sydney #1"
+			],
+			"pattern": "^.+$"
+		},
+		"maxPlayers": {
+			"$id": "#root/maxPlayers",
+			"title": "Maxplayers",
+			"type": "integer",
+			"examples": [
+				32
+			],
+			"default": 0
+		},
+		"numPlayers": {
+			"$id": "#root/numPlayers",
+			"title": "Numplayers",
+			"type": "integer",
+			"examples": [
+				17
+			],
+			"default": 0
+		},
+		"gamemode": {
+			"$id": "#root/gamemode",
+			"title": "Gamemode",
+			"type": "object",
+			"required": [
+				"matchmaking",
+				"type",
+				"vanilla"
+			],
+			"properties": {
+				"matchmaking": {
+					"$id": "#root/gamemode/matchmaking",
+					"title": "Matchmaking",
+					"type": "boolean",
+					"examples": [
+						false
+					],
+					"default": false
+				},
+				"type": {
+					"$id": "#root/gamemode/type",
+					"title": "Type",
+					"type": "string",
+					"default": "",
+					"examples": [
+						"ctf",
+						"Capture the Flag",
+						"Arena",
+						"vsh",
+						"Versus Saxton Hale"
+					],
+					"pattern": "^.*$"
+				},
+				"vanilla": {
+					"$id": "#root/gamemode/vanilla",
+					"title": "Vanilla",
+					"type": "boolean",
+					"examples": [
+						false
+					],
+					"default": false
+				}
+			}
+		}
+
+	}
+}

--- a/data/schemas/validate_historyGet.json
+++ b/data/schemas/validate_historyGet.json
@@ -1,0 +1,21 @@
+{
+  "definitions": {},
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://example.com/object1688894919.json",
+  "title": "Root",
+  "type": "object",
+  "required": [
+      "players"
+  ],
+  "properties": {
+    "players": {
+      "$id": "#root/players",
+      "title": "Players",
+      "type": "array",
+      "default": [],
+      "items": {
+        "$ref": "validate_playerResponse.json"
+      }
+    }
+  }
+}

--- a/data/schemas/validate_playerPost.json
+++ b/data/schemas/validate_playerPost.json
@@ -1,0 +1,27 @@
+{
+	"definitions": {},
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "https://example.com/object1688895775.json",
+	"title": "Root",
+	"type": "object",
+	"required": [
+		"users"
+	],
+	"properties": {
+		"users": {
+			"$id": "#root/users",
+			"title": "Users",
+			"type": "array",
+			"default": [],
+			"items":{
+				"$id": "#root/users/items",
+				"title": "Items",
+				"type": "integer",
+				"examples": [
+					76561198137175279
+				],
+				"default": 0
+			}
+		}
+	}
+}

--- a/data/schemas/validate_playerPostResponse.json
+++ b/data/schemas/validate_playerPostResponse.json
@@ -1,0 +1,21 @@
+{
+  "definitions": {},
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://example.com/object1688894919.json",
+  "title": "Root",
+  "type": "object",
+  "required": [
+      "players"
+  ],
+  "properties": {
+    "players": {
+      "$id": "#root/players",
+      "title": "Players",
+      "type": "array",
+      "default": [],
+      "items": {
+        "$ref": "validate_playerResponse.json"
+      }
+    }
+  }
+}

--- a/data/schemas/validate_playerPut.json
+++ b/data/schemas/validate_playerPut.json
@@ -1,0 +1,40 @@
+{
+	"definitions": {},
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "https://example.com/object1688895985.json",
+	"title": "Root",
+	"type": "object",
+	"patternProperties": {
+		"^[0-9]{17}$": {
+			"type": "object",
+			"required": [
+				"tags",
+				"customData"
+			],
+			"properties": {
+				"tags": {
+					"title": "Tags",
+					"type": "array",
+					"default": [],
+					"items":{
+						"title": "Items",
+						"type": "string",
+						"default": "",
+						"examples": [
+							"Suspicious"
+						],
+						"pattern": "^.*$"
+					}
+				},
+				"customData": {
+					"title": "Customdata",
+					"type": "object",
+					"required": [
+					],
+					"properties": {
+					}
+				}
+			}
+		}
+	}
+}

--- a/data/schemas/validate_playerPutResponse.json
+++ b/data/schemas/validate_playerPutResponse.json
@@ -1,0 +1,17 @@
+{
+	"definitions": {},
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "https://example.com/object1688897635.json",
+	"title": "Root",
+	"type": "object",
+	"required": [
+		"errors"
+	],
+	"properties": {
+		"errors": {
+			"$id": "#root/errors",
+			"title": "Errors",
+			"type": "object"
+		}
+	}
+}

--- a/data/schemas/validate_playerResponse.json
+++ b/data/schemas/validate_playerResponse.json
@@ -138,92 +138,99 @@
 		"gameInfo": {
 			"$id": "#root/gameInfo",
 			"title": "Gameinfo",
-			"type": "object",
-			"required": [
-				"team",
-				"ping",
-				"kills",
-				"deaths",
-				"time",
-				"state",
-				"loss",
-				"userid"
-			],
-			"properties": {
-				"team": {
-					"$id": "#root/gameInfo/team",
-					"title": "Team",
-					"type": "integer",
-					"examples": [
-						3
+			"anyOf": [
+				{
+					"type": "object",
+					"required": [
+						"team",
+						"ping",
+						"kills",
+						"deaths",
+						"time",
+						"state",
+						"loss",
+						"userid"
 					],
-					"default": 0
+					"properties": {
+						"team": {
+							"$id": "#root/gameInfo/team",
+							"title": "Team",
+							"type": "integer",
+							"examples": [
+								3
+							],
+							"default": 0
+						},
+						"ping": {
+							"$id": "#root/gameInfo/ping",
+							"title": "Ping",
+							"type": "integer",
+							"examples": [
+								64
+							],
+							"default": 0
+						},
+						"kills": {
+							"$id": "#root/gameInfo/kills",
+							"title": "Kills",
+							"type": "integer",
+							"examples": [
+								0
+							],
+							"default": 0
+						},
+						"deaths": {
+							"$id": "#root/gameInfo/deaths",
+							"title": "Deaths",
+							"type": "integer",
+							"examples": [
+								0
+							],
+							"default": 0
+						},
+						"time": {
+							"$id": "#root/gameInfo/time",
+							"title": "Time",
+							"type": "integer",
+							"default": 0,
+							"examples": [
+								5872
+							]
+						},
+						"state": {
+							"$id": "#root/gameInfo/state",
+							"title": "State",
+							"type": "string",
+							"default": "",
+							"examples": [
+								"spawning"
+							],
+							"pattern": "^.*$"
+						},
+						"loss": {
+							"$id": "#root/gameInfo/loss",
+							"title": "Loss",
+							"type": "integer",
+							"default": 0,
+							"examples": [
+								56
+							]
+						},
+						"userid": {
+							"$id": "#root/gameInfo/userid",
+							"title": "Userid",
+							"type": "string",
+							"default": "",
+							"examples": [
+								"301"
+							]
+						}
+					}
 				},
-				"ping": {
-					"$id": "#root/gameInfo/ping",
-					"title": "Ping",
-					"type": "integer",
-					"examples": [
-						64
-					],
-					"default": 0
-				},
-				"kills": {
-					"$id": "#root/gameInfo/kills",
-					"title": "Kills",
-					"type": "integer",
-					"examples": [
-						0
-					],
-					"default": 0
-				},
-				"deaths": {
-					"$id": "#root/gameInfo/deaths",
-					"title": "Deaths",
-					"type": "integer",
-					"examples": [
-						0
-					],
-					"default": 0
-				},
-				"time": {
-					"$id": "#root/gameInfo/time",
-					"title": "Time",
-					"type": "integer",
-					"default": 0,
-					"examples": [
-						5872
-					]
-				},
-				"state": {
-					"$id": "#root/gameInfo/state",
-					"title": "State",
-					"type": "string",
-					"default": "",
-					"examples": [
-						"spawning"
-					],
-					"pattern": "^.*$"
-				},
-				"loss": {
-					"$id": "#root/gameInfo/loss",
-					"title": "Loss",
-					"type": "integer",
-					"default": 0,
-					"examples": [
-						56
-					]
-				},
-				"userid": {
-					"$id": "#root/gameInfo/userid",
-					"title": "Userid",
-					"type": "string",
-					"default": "",
-					"examples": [
-						"301"
-					]
+				{
+					"type": "null"
 				}
-			}
+			]
 		},
 		"customData": {
 			"$id": "#root/customData",

--- a/data/schemas/validate_playerResponse.json
+++ b/data/schemas/validate_playerResponse.json
@@ -1,0 +1,241 @@
+{
+	"definitions": {},
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "https://example.com/object1688732225.json",
+	"title": "Root",
+	"type": "object",
+	"required": [
+		"isSelf",
+		"name",
+		"steamID64",
+		"steamInfo",
+		"gameInfo",
+		"customData",
+		"tags"
+	],
+	"properties": {
+		"isSelf": {
+			"$id": "#root/isSelf",
+			"title": "Isself",
+			"type": "boolean",
+			"examples": [
+				false
+			],
+			"default": true
+		},
+		"name": {
+			"$id": "#root/name",
+			"title": "Name",
+			"type": "string",
+			"default": "None",
+			"examples": [
+				"Lilith"
+			],
+			"pattern": "^.+$"
+		},
+		"steamID64": {
+			"$id": "#root/steamID64",
+			"title": "Steamid64",
+			"type": "integer",
+			"default": 0,
+			"examples": [
+				76561198210264393
+			],
+			"pattern": "^\\d+$"
+		},
+		"steamInfo": {
+			"$id": "#root/steamInfo",
+			"title": "Steaminfo",
+			"anyOf": [
+				{
+					"type": "object",
+					"required": [
+						"accountName",
+						"pfp",
+						"pfphash",
+						"vacBans",
+						"isFriend",
+						"timecreated",
+						"loccountrycode"
+					],
+					"properties": {
+						"accountName": {
+							"$id": "#root/steamInfo/accountName",
+							"title": "Accountname",
+							"type": "string",
+							"default": "",
+							"examples": [
+								"Lilith"
+							],
+							"pattern": "^.*$"
+						},
+						"pfp": {
+							"$id": "#root/steamInfo/pfp",
+							"title": "Pfp",
+							"type": "string",
+							"default": "",
+							"examples": [
+								"https://avatars.akamai.steamstatic.com/427ef7d5f8ad7b21678f69bc8afc95786cf38fe6_full.jpg",
+								"https://avatars.steamstatic.com/427ef7d5f8ad7b21678f69bc8afc95786cf38fe6_full.jpg"
+							],
+							"pattern": "^.*$"
+						},
+						"pfphash": {
+							"$id": "#root/steamInfo/pfphash",
+							"title": "Pfphash",
+							"type": "string",
+							"default": "",
+							"examples": [
+								"f556979c2d55a633a063ff2b7b1eae1d2c2812fc"
+							],
+							"pattern": "^.*$"
+						},
+						"vacBans": {
+							"$id": "#root/steamInfo/vacBans",
+							"title": "Vacbans",
+							"type": "string",
+							"default": "",
+							"examples": [
+								""
+							],
+							"pattern": "^.*$"
+						},
+						"isFriend": {
+							"$id": "#root/steamInfo/isFriend",
+							"title": "Isfriend",
+							"type": "boolean",
+							"examples": [
+								true
+							],
+							"default": false
+						},
+						"timecreated": {
+							"$id": "#root/steamInfo/timecreated",
+							"title": "Timecreated",
+							"type": "integer",
+							"examples": [
+								1570311509
+							],
+							"default": 0
+						},
+						"loccountrycode": {
+							"$id": "#root/steamInfo/loccountrycode",
+							"title": "Loccountrycode",
+							"type": "string",
+							"default": "",
+							"examples": [
+								"AU"
+							],
+							"pattern": "^.*$"
+						}
+					}
+				},
+				{
+					"type": "null"
+				}
+			]
+		},
+		"gameInfo": {
+			"$id": "#root/gameInfo",
+			"title": "Gameinfo",
+			"type": "object",
+			"required": [
+				"team",
+				"ping",
+				"kills",
+				"deaths",
+				"time",
+				"state",
+				"loss",
+				"userid"
+			],
+			"properties": {
+				"team": {
+					"$id": "#root/gameInfo/team",
+					"title": "Team",
+					"type": "integer",
+					"examples": [
+						3
+					],
+					"default": 0
+				},
+				"ping": {
+					"$id": "#root/gameInfo/ping",
+					"title": "Ping",
+					"type": "integer",
+					"examples": [
+						64
+					],
+					"default": 0
+				},
+				"kills": {
+					"$id": "#root/gameInfo/kills",
+					"title": "Kills",
+					"type": "integer",
+					"examples": [
+						0
+					],
+					"default": 0
+				},
+				"deaths": {
+					"$id": "#root/gameInfo/deaths",
+					"title": "Deaths",
+					"type": "integer",
+					"examples": [
+						0
+					],
+					"default": 0
+				},
+				"time": {
+					"$id": "#root/gameInfo/time",
+					"title": "Time",
+					"type": "integer",
+					"default": 0,
+					"examples": [
+						5872
+					]
+				},
+				"state": {
+					"$id": "#root/gameInfo/state",
+					"title": "State",
+					"type": "string",
+					"default": "",
+					"examples": [
+						"spawning"
+					],
+					"pattern": "^.*$"
+				},
+				"loss": {
+					"$id": "#root/gameInfo/loss",
+					"title": "Loss",
+					"type": "integer",
+					"default": 0,
+					"examples": [
+						56
+					]
+				},
+				"userid": {
+					"$id": "#root/gameInfo/userid",
+					"title": "Userid",
+					"type": "string",
+					"default": "",
+					"examples": [
+						"301"
+					]
+				}
+			}
+		},
+		"customData": {
+			"$id": "#root/customData",
+			"title": "Customdata",
+			"type": "object"
+		},
+		"tags": {
+			"$id": "#root/tags",
+			"title": "Tags",
+			"type": "array",
+			"default": []
+		}
+	}
+}
+

--- a/data/schemas/validate_prefGet.json
+++ b/data/schemas/validate_prefGet.json
@@ -1,0 +1,23 @@
+{
+	"definitions": {},
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "https://example.com/object1688897693.json",
+	"title": "Root",
+	"type": "object",
+	"required": [
+		"internal",
+		"external"
+	],
+	"properties": {
+		"internal": {
+			"$id": "#root/internal",
+			"title": "Internal",
+			"type": "object"
+		},
+		"external": {
+			"$id": "#root/external",
+			"title": "External",
+			"type": "object"
+		}
+	}
+}

--- a/data/schemas/validate_prefPost.json
+++ b/data/schemas/validate_prefPost.json
@@ -1,0 +1,23 @@
+{
+	"definitions": {},
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "https://example.com/object1688897693.json",
+	"title": "Root",
+	"type": "object",
+	"required": [
+		"internal",
+		"external"
+	],
+	"properties": {
+		"internal": {
+			"$id": "#root/internal",
+			"title": "Internal",
+			"type": "object"
+		},
+		"external": {
+			"$id": "#root/external",
+			"title": "External",
+			"type": "object"
+		}
+	}
+}

--- a/data/schemas/validate_prefPostResponse.json
+++ b/data/schemas/validate_prefPostResponse.json
@@ -1,0 +1,41 @@
+{
+	"definitions": {},
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "https://example.com/object1688897808.json",
+	"title": "Root",
+	"type": "object",
+	"required": [
+		"changes",
+		"errors"
+	],
+	"properties": {
+		"changes": {
+			"$id": "#root/changes",
+			"title": "Changes",
+			"type": "object",
+			"required": [
+				"internal",
+				"external"
+			],
+			"properties": {
+				"internal": {
+					"$id": "#root/changes/internal",
+					"title": "Internal",
+					"type": "object"
+				},
+				"external": {
+					"$id": "#root/changes/external",
+					"title": "External",
+					"type": "object"
+				}
+
+			}
+		},
+		"errors": {
+			"$id": "#root/errors",
+			"title": "Errors",
+			"type": "object"
+		}
+
+	}
+}


### PR DESCRIPTION
Create: `data/schemas/` directories

Add all basic payload validation schemas to repo, can be used for payload validation by code, or to generate docs. 