### PR TITLE
update playerResponse validation schema to implement newest modifs

### DIFF
--- a/data/schemas/validate_playerResponse.json
+++ b/data/schemas/validate_playerResponse.json
@@ -63,7 +63,7 @@
 						"friends"
 					],
 					"properties": {
-						"accountName": {
+						"name": {
 							"$id": "#root/steamInfo/name",
 							"title": "name",
 							"type": "string",

--- a/data/schemas/validate_playerResponse.json
+++ b/data/schemas/validate_playerResponse.json
@@ -53,9 +53,9 @@
 						"name",
 						"profileUrl",
 						"pfp",
-						"pfphash",
+						"pfpHash",
 						"profileVisibility",
-						"timecreated",
+						"timeCreated",
 						"countryCode",
 						"vacBans",
 						"gameBans",
@@ -105,9 +105,9 @@
 							],
 							"pattern": "^.*$"
 						},
-						"pfphash": {
-							"$id": "#root/steamInfo/pfphash",
-							"title": "Pfphash",
+						"pfpHash": {
+							"$id": "#root/steamInfo/pfpHash",
+							"title": "PfpHash",
 							"type": "string",
 							"default": "",
 							"examples": [
@@ -173,9 +173,9 @@
 							},
 							"default": []
 						},
-						"timecreated": {
-							"$id": "#root/steamInfo/timecreated",
-							"title": "Timecreated",
+						"timeCreated": {
+							"$id": "#root/steamInfo/timeCreated",
+							"title": "TimeCreated",
 							"type": "integer",
 							"examples": [
 								1570311509

--- a/data/schemas/validate_playerResponse.json
+++ b/data/schemas/validate_playerResponse.json
@@ -136,10 +136,17 @@
 						"daysSinceLastBan": {
 							"$id": "#root/steamInfo/daysSinceLastBan",
 							"title": "DaysSinceLastBan",
-							"type": "integer",
-							"default": 0,
-							"examples": [
-								726
+							"anyOf": [
+								{
+									"type": "integer",
+									"default": 0,
+									"examples": [
+										726
+									]
+								},
+								{
+									"type": "null"
+								}
 							]
 						},
 						"friends": {

--- a/data/schemas/validate_playerResponse.json
+++ b/data/schemas/validate_playerResponse.json
@@ -50,22 +50,36 @@
 				{
 					"type": "object",
 					"required": [
-						"accountName",
+						"name",
+						"profileUrl",
 						"pfp",
 						"pfphash",
-						"vacBans",
-						"isFriend",
+						"profileVisibility",
 						"timecreated",
-						"loccountrycode"
+						"countryCode",
+						"vacBans",
+						"gameBans",
+						"daysSinceLastBan",
+						"friends"
 					],
 					"properties": {
 						"accountName": {
-							"$id": "#root/steamInfo/accountName",
-							"title": "Accountname",
+							"$id": "#root/steamInfo/name",
+							"title": "name",
 							"type": "string",
 							"default": "",
 							"examples": [
 								"Lilith"
+							],
+							"pattern": "^.*$"
+						},
+						"profileUrl": {
+							"$id": "#root/steamInfo/profileUrl",
+							"title": "ProfileUrl",
+							"type": "string",
+							"default": "",
+							"examples": [
+								"https://steamcommunity.com/id/__lilith"	
 							],
 							"pattern": "^.*$"
 						},
@@ -77,6 +91,17 @@
 							"examples": [
 								"https://avatars.akamai.steamstatic.com/427ef7d5f8ad7b21678f69bc8afc95786cf38fe6_full.jpg",
 								"https://avatars.steamstatic.com/427ef7d5f8ad7b21678f69bc8afc95786cf38fe6_full.jpg"
+							],
+							"pattern": "^.*$"
+						},
+						"profileVisibility": {
+							"$id": "#root/steamInfo/profileVisibility",
+							"title": "ProfileVisibility",
+							"type": "string",
+							"default": "Private",
+							"examples": [
+								"Public",
+								"Private"
 							],
 							"pattern": "^.*$"
 						},
@@ -92,22 +117,61 @@
 						},
 						"vacBans": {
 							"$id": "#root/steamInfo/vacBans",
-							"title": "Vacbans",
-							"type": "string",
-							"default": "",
+							"title": "VacBans",
+							"type": "integer",
+							"default": 0,
 							"examples": [
-								""
-							],
-							"pattern": "^.*$"
+								1
+							]
 						},
-						"isFriend": {
-							"$id": "#root/steamInfo/isFriend",
-							"title": "Isfriend",
-							"type": "boolean",
+						"gameBans": {
+							"$id": "#root/steamInfo/gameBans",
+							"title": "GameBans",
+							"type": "integer",
+							"default": 0,
 							"examples": [
-								true
-							],
-							"default": false
+								1
+							]
+						},
+						"daysSinceLastBan": {
+							"$id": "#root/steamInfo/daysSinceLastBan",
+							"title": "DaysSinceLastBan",
+							"type": "integer",
+							"default": 0,
+							"examples": [
+								726
+							]
+						},
+						"friends": {
+							"$id": "#root/steamInfo/friends",
+							"title": "Friends",
+							"type": "array",
+							"items": {
+								"type": "object",
+								"required": [
+									"steamID64",
+									"friendSince"
+								],
+								"properties": {
+									"steamID64": {
+										"title": "friendsSteamID64",
+										"type": "integer",
+										"default": 0,
+										"examples": [
+											76561198033416930
+										]
+									},
+									"friendSince": {
+										"title": "friendsFriendSince",
+										"type": "integer",
+										"default": 0,
+										"examples": [
+											1428650342
+										]
+									}
+								}
+							},
+							"default": []
 						},
 						"timecreated": {
 							"$id": "#root/steamInfo/timecreated",
@@ -118,9 +182,9 @@
 							],
 							"default": 0
 						},
-						"loccountrycode": {
-							"$id": "#root/steamInfo/loccountrycode",
-							"title": "Loccountrycode",
+						"countryCode": {
+							"$id": "#root/steamInfo/countryCode",
+							"title": "CountryCode",
 							"type": "string",
 							"default": "",
 							"examples": [


### PR DESCRIPTION
We add several new fields to the steamInfo object, as well as rename a few keys.

Please review with fresh eyes and let me know if I forgot anything.

Important notes:
- no more `isFriend` key. Now we have a `friends` list of objects that contain a steamID64 and a time of friends since
- we have `vacBans` and `gameBans` keys that track total number of bans on an account, as well as `daysSinceLastBan` to track time
- `loccountrycode` -> `countryCode`
- add `pfpUrl`
- add `profileVisibility` (noteably this is encoded as string, should we leave it as the int it gets returned as by steam api?)