### PR TITLE
integrate G15 parsing into command loop, deprecate tf_lobby_debug....

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /target
 /log
+.idea/
+.vscode/
+.env

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Troubleshooting:
 * Update rust with `rustup update`
 
 ## Testing
-1. Run all tests in `./test/` with `cargo test`
+1. Run all tests in `./tests/` with `cargo test`
 
 ## Contributing
 Always run `cargo fmt` before submitting your Merge Request

--- a/src/io.rs
+++ b/src/io.rs
@@ -10,6 +10,7 @@ use tokio::sync::mpsc::Sender;
 
 use crate::state::State;
 
+use self::g15::G15Parser;
 use self::command_manager::CommandManager;
 use self::command_manager::KickReason;
 use self::logwatcher::LogWatcher;
@@ -69,7 +70,7 @@ pub struct IOManager {
     command_send: Sender<Commands>,
     command_manager: CommandManager,
     log_watcher: Option<LogWatcher>,
-    parser: g15::G15Parser,
+    parser: G15Parser,
     regex_status: Regex,
     regex_chat: Regex,
     regex_kill: Regex,
@@ -89,7 +90,7 @@ impl IOManager {
             command_send: tx,
             command_manager,
             log_watcher: None,
-            parser: g15::G15Parser::new(),
+            parser: G15Parser::new(),
             regex_status: Regex::new(REGEX_STATUS).unwrap(),
             regex_chat: Regex::new(REGEX_CHAT).unwrap(),
             regex_kill: Regex::new(REGEX_KILL).unwrap(),

--- a/src/io.rs
+++ b/src/io.rs
@@ -69,7 +69,7 @@ pub struct IOManager {
     command_send: Sender<Commands>,
     command_manager: CommandManager,
     log_watcher: Option<LogWatcher>,
-
+    parser: g15::G15Parser,
     regex_status: Regex,
     regex_chat: Regex,
     regex_kill: Regex,
@@ -89,7 +89,7 @@ impl IOManager {
             command_send: tx,
             command_manager,
             log_watcher: None,
-
+            parser: g15::G15Parser::new(),
             regex_status: Regex::new(REGEX_STATUS).unwrap(),
             regex_chat: Regex::new(REGEX_CHAT).unwrap(),
             regex_kill: Regex::new(REGEX_KILL).unwrap(),
@@ -125,8 +125,7 @@ impl IOManager {
             .await?;
         Ok(match command {
             Commands::G15 => {
-                let parser = g15::G15Parser::new();
-                let players = parser.parse_g15(&resp);
+                let players = self.parser.parse_g15(&resp);
                 Some(IOOutput::G15(players))
             }
             Commands::Kick(_, _) => {

--- a/src/io.rs
+++ b/src/io.rs
@@ -15,7 +15,6 @@ use self::command_manager::KickReason;
 use self::logwatcher::LogWatcher;
 use self::regexes::ChatMessage;
 use self::regexes::Hostname;
-use self::regexes::LobbyLine;
 use self::regexes::Map;
 use self::regexes::PlayerCount;
 use self::regexes::PlayerKill;
@@ -24,7 +23,6 @@ use self::regexes::REGEX_CHAT;
 use self::regexes::REGEX_HOSTNAME;
 use self::regexes::REGEX_IP;
 use self::regexes::REGEX_KILL;
-use self::regexes::REGEX_LOBBY;
 use self::regexes::REGEX_MAP;
 use self::regexes::REGEX_PLAYERCOUNT;
 
@@ -44,7 +42,6 @@ pub enum IOOutput {
     ServerIP(ServerIP),
     Map(Map),
     PlayerCount(PlayerCount),
-    Lobby(LobbyLine),
     G15(Vec<g15::G15Player>),
 }
 
@@ -73,7 +70,6 @@ pub struct IOManager {
     log_watcher: Option<LogWatcher>,
 
     regex_status: Regex,
-    regex_lobby: Regex,
     regex_chat: Regex,
     regex_kill: Regex,
     regex_hostname: Regex,
@@ -94,7 +90,6 @@ impl IOManager {
             log_watcher: None,
 
             regex_status: Regex::new(REGEX_STATUS).unwrap(),
-            regex_lobby: Regex::new(REGEX_LOBBY).unwrap(),
             regex_chat: Regex::new(REGEX_CHAT).unwrap(),
             regex_kill: Regex::new(REGEX_KILL).unwrap(),
             regex_hostname: Regex::new(REGEX_HOSTNAME).unwrap(),

--- a/src/io/command_manager.rs
+++ b/src/io/command_manager.rs
@@ -5,6 +5,8 @@ use tokio::net::TcpStream;
 
 use crate::state::State;
 
+use super::Commands;
+
 #[derive(Debug)]
 pub enum KickReason {
     None,
@@ -28,8 +30,9 @@ pub struct CommandManager {
     rcon: Option<Connection<TcpStream>>,
 }
 
-pub const CMD_STATUS: &str = "status";
-pub const CMD_TF_LOBBY_DEBUG: &str = "tf_lobby_debug";
+pub const CMD_STATUS: Commands = Commands::Status;
+// pub const CMD_TF_LOBBY_DEBUG: &str = "tf_lobby_debug";
+pub const CMD_G15_DUMPPLAYER: Commands = Commands::G15;
 
 impl CommandManager {
     pub fn new() -> CommandManager {

--- a/src/io/command_manager.rs
+++ b/src/io/command_manager.rs
@@ -30,9 +30,6 @@ pub struct CommandManager {
     rcon: Option<Connection<TcpStream>>,
 }
 
-pub const CMD_STATUS: Commands = Commands::Status;
-pub const CMD_G15_DUMPPLAYER: Commands = Commands::G15;
-
 impl CommandManager {
     pub fn new() -> CommandManager {
         CommandManager { rcon: None }
@@ -74,10 +71,6 @@ impl CommandManager {
         }
 
         out
-    }
-
-    pub fn kick_player_command(player_userid: &str, reason: KickReason) -> String {
-        format!("callvote kick \"{} {}\"", player_userid, reason)
     }
 
     pub fn send_chat_command(message: &str) -> String {

--- a/src/io/command_manager.rs
+++ b/src/io/command_manager.rs
@@ -31,7 +31,6 @@ pub struct CommandManager {
 }
 
 pub const CMD_STATUS: Commands = Commands::Status;
-// pub const CMD_TF_LOBBY_DEBUG: &str = "tf_lobby_debug";
 pub const CMD_G15_DUMPPLAYER: Commands = Commands::G15;
 
 impl CommandManager {

--- a/src/io/g15.rs
+++ b/src/io/g15.rs
@@ -3,8 +3,9 @@
 
 use regex::{Regex, Captures};
 use std::fmt;
-use std::fs;
 use std::num::ParseIntError;
+
+use crate::player::Team;
 
 #[derive(Debug)]
 pub enum Error {
@@ -104,7 +105,10 @@ pub fn parse_team(caps: Captures, players: &mut [G15Player]) -> Result<(), Error
     let idx: usize = caps[1].parse()?;
     let team:u32 = caps[2].parse()?;
     let mut player_ref = players.get_mut(idx).ok_or(Error::IndexOutOfBounds)?;
-    player_ref.team = Some(team);
+    player_ref.team = match Team::try_from(team) {
+        Ok(val) => Some(val),
+        Err(err) => None,
+    };
     Ok(())
 }
 
@@ -174,7 +178,7 @@ pub struct G15Player {
     pub score: Option<u32>,       // eg 16
     pub deaths: Option<u32>,      // eg 5
     pub sid3: Option<String>,     // eg [U:1:111216987]
-    pub team: Option<u32>,        // eg 3
+    pub team: Option<Team>,        // eg 3
     pub health: Option<u32>,      // eg 125
     pub ammo: Option<u32>,        // eg 6
     pub connected: Option<bool>,  // eg true

--- a/src/io/g15.rs
+++ b/src/io/g15.rs
@@ -1,7 +1,7 @@
 #![allow(non_upper_case_globals)]
 #![allow(unused_variables)]
 
-use regex::{Regex, Captures};
+use regex::{Captures, Regex};
 use std::fmt;
 use std::num::ParseIntError;
 
@@ -10,14 +10,14 @@ use crate::player::Team;
 #[derive(Debug)]
 pub enum Error {
     /// Occurs when m_someArray[X] has some X greater than 33 (since these are static 34 element arrays)
-    IndexOutOfBounds, 
+    IndexOutOfBounds,
     /// Occurs when an int fails to parse into the given unsigned range (u32 or u64)
-    ParseError(ParseIntError),           
+    ParseError(ParseIntError),
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f,"bad G15 value: {:?}", self)
+        write!(f, "bad G15 value: {:?}", self)
     }
 }
 
@@ -29,12 +29,18 @@ impl From<ParseIntError> for Error {
 
 /// A RegMatch struct contains a Regex and the corresponding function to add the result to the G15Player vec
 /// if the regex results in a match.
-pub struct RegMatch(Regex, fn(caps: Captures, players: &mut [G15Player])->Result<(), Error>);
+pub struct RegMatch(
+    Regex,
+    fn(caps: Captures, players: &mut [G15Player]) -> Result<(), Error>,
+);
 impl RegMatch {
-    pub fn new(reg_str: &str, func: fn(caps: Captures, players: &mut [G15Player])->Result<(), Error>) -> RegMatch {
+    pub fn new(
+        reg_str: &str,
+        func: fn(caps: Captures, players: &mut [G15Player]) -> Result<(), Error>,
+    ) -> RegMatch {
         // Unwrap, because these Regex's should statically compile and we want to panic if they don't.
         let regers = Regex::new(reg_str).unwrap();
-        RegMatch (regers, func)
+        RegMatch(regers, func)
     }
 }
 
@@ -103,12 +109,11 @@ pub fn parse_connected(caps: Captures, players: &mut [G15Player]) -> Result<(), 
 pub const REGEX_I_TEAM: &str = r#"^m_iTeam\[(\d+)\]\s+integer\s+\(([0-3])\)$"#;
 pub fn parse_team(caps: Captures, players: &mut [G15Player]) -> Result<(), Error> {
     let idx: usize = caps[1].parse()?;
-    let team:u32 = caps[2].parse()?;
+    let team: u32 = caps[2].parse()?;
     let mut player_ref = players.get_mut(idx).ok_or(Error::IndexOutOfBounds)?;
     player_ref.team = Team::try_from(team).ok();
     Ok(())
 }
-
 
 /// `m_bAlive[0] bool (false)` --> capture groups: `(player idx)` `(alive status (true/false))`
 pub const REGEX_B_ALIVE: &str = r#"^m_bAlive\[(\d+)\]\s+bool\s+\((false|true)\)$"#;
@@ -164,35 +169,34 @@ pub fn parse_userid(caps: Captures, players: &mut [G15Player]) -> Result<(), Err
     Ok(())
 }
 
-
 /// The G15Player struct contains all the data per player searched.
 /// Each of the elements may be Null, as the parsing could fail on a particular line, leaving the value undefined.
 /// We still want the rest of the useful data though
 #[derive(Debug, Clone)]
 pub struct G15Player {
-    pub name: Option<String>,     // eg "Lilith"
-    pub ping: Option<u32>,        // eg 21
-    pub score: Option<u32>,       // eg 16
-    pub deaths: Option<u32>,      // eg 5
-    pub sid3: Option<String>,     // eg [U:1:111216987]
-    pub team: Option<Team>,        // eg 3
-    pub health: Option<u32>,      // eg 125
-    pub ammo: Option<u32>,        // eg 6
-    pub connected: Option<bool>,  // eg true
-    pub valid: Option<bool>,      // eg true
-    pub alive: Option<bool>,      // eg true
-    pub userid: Option<String>,   // eg "301"
+    pub name: Option<String>,    // eg "Lilith"
+    pub ping: Option<u32>,       // eg 21
+    pub score: Option<u32>,      // eg 16
+    pub deaths: Option<u32>,     // eg 5
+    pub sid3: Option<String>,    // eg [U:1:111216987]
+    pub team: Option<Team>,      // eg 3
+    pub health: Option<u32>,     // eg 125
+    pub ammo: Option<u32>,       // eg 6
+    pub connected: Option<bool>, // eg true
+    pub valid: Option<bool>,     // eg true
+    pub alive: Option<bool>,     // eg true
+    pub userid: Option<String>,  // eg "301"
 }
 impl G15Player {
     pub fn new() -> G15Player {
         G15Player {
-            name: None, 
-            ping: None, 
-            score: None, 
-            deaths: None, 
-            sid3: None, 
-            team: None, 
-            health: None, 
+            name: None,
+            ping: None,
+            score: None,
+            deaths: None,
+            sid3: None,
+            team: None,
+            health: None,
             ammo: None,
             alive: None,
             connected: None,
@@ -208,34 +212,36 @@ impl Default for G15Player {
 }
 
 /// The G15Parser struct contains a vector of compiled Regex automata to parse strings out of
-/// the g15_dumpplayer console output. 
+/// the g15_dumpplayer console output.
 /// It implements a `parse_g15` fn to use these to parse useful player data from the output.
 pub struct G15Parser {
     patterns: Vec<RegMatch>,
 }
 impl G15Parser {
     pub fn new() -> G15Parser {
-        G15Parser { patterns: vec![
-            RegMatch::new(REGEX_I_AMMO, parse_ammo), 
-            RegMatch::new(REGEX_SZ_NAME, parse_name),
-            RegMatch::new(REGEX_I_PING, parse_ping),
-            RegMatch::new(REGEX_I_SCORE, parse_score),
-            RegMatch::new(REGEX_I_DEATHS, parse_deaths),
-            RegMatch::new(REGEX_B_CONNECTED, parse_connected),
-            RegMatch::new(REGEX_I_TEAM, parse_team),
-            RegMatch::new(REGEX_B_ALIVE, parse_alive),
-            RegMatch::new(REGEX_I_HEALTH, parse_health),
-            RegMatch::new(REGEX_I_SID3, parse_sid3),
-            RegMatch::new(REGEX_B_VALID, parse_valid),
-            RegMatch::new(REGEX_I_USERID, parse_userid),
-            ] }
+        G15Parser {
+            patterns: vec![
+                RegMatch::new(REGEX_I_AMMO, parse_ammo),
+                RegMatch::new(REGEX_SZ_NAME, parse_name),
+                RegMatch::new(REGEX_I_PING, parse_ping),
+                RegMatch::new(REGEX_I_SCORE, parse_score),
+                RegMatch::new(REGEX_I_DEATHS, parse_deaths),
+                RegMatch::new(REGEX_B_CONNECTED, parse_connected),
+                RegMatch::new(REGEX_I_TEAM, parse_team),
+                RegMatch::new(REGEX_B_ALIVE, parse_alive),
+                RegMatch::new(REGEX_I_HEALTH, parse_health),
+                RegMatch::new(REGEX_I_SID3, parse_sid3),
+                RegMatch::new(REGEX_B_VALID, parse_valid),
+                RegMatch::new(REGEX_I_USERID, parse_userid),
+            ],
+        }
     }
-    
+
     /// Parse a g15_dumpplayer string via Regex search.
     /// We only extract useful data here, so drop most data.
     pub fn parse_g15(&self, g15_log: &str) -> Vec<G15Player> {
         let mut players: Vec<G15Player> = vec![G15Player::new(); 34];
-        let lines = g15_log.split('\n'); 
+        let lines = g15_log.split('\n');
 
         for line in lines {
             for pat in &self.patterns {
@@ -247,7 +253,7 @@ impl G15Parser {
                         Err(why) => println!("Parse error - {} at line {}", why, line),
                         Ok(value) => (),
                     }
-                } 
+                }
             }
         }
         players.retain(|x| x.valid.unwrap_or(false));

--- a/src/io/g15.rs
+++ b/src/io/g15.rs
@@ -105,10 +105,7 @@ pub fn parse_team(caps: Captures, players: &mut [G15Player]) -> Result<(), Error
     let idx: usize = caps[1].parse()?;
     let team:u32 = caps[2].parse()?;
     let mut player_ref = players.get_mut(idx).ok_or(Error::IndexOutOfBounds)?;
-    player_ref.team = match Team::try_from(team) {
-        Ok(val) => Some(val),
-        Err(err) => None,
-    };
+    player_ref.team = Team::try_from(team).ok();
     Ok(())
 }
 

--- a/src/io/regexes.rs
+++ b/src/io/regexes.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use regex::Captures;
 use steamid_ng::{SteamID, SteamIDError};
 
-use crate::player::{PlayerState, Team};
+use crate::player::PlayerState;
 
 /*
     Useful commands:

--- a/src/io/regexes.rs
+++ b/src/io/regexes.rs
@@ -11,8 +11,7 @@ use crate::player::{PlayerState, Team};
 /*
     Useful commands:
         status
-        tf_lobby_debug
-        tf_party_debug //Not sure if this is actually useful, not really necessary
+        g15_dumpplayer
 
         callvote kick <userid>
         vote option<1/2> // Can't really use
@@ -172,37 +171,6 @@ fn get_time(input: &str) -> Option<u32> {
     }
 
     Some(t)
-}
-
-// Reads lines from output of the "tf_lobby_debug" command
-// Includes the team of players on the server
-// NOTE: Teams are stored as INVADERS/DEFENDERS and does not swap when Red/Blu swaps so it cannot
-// be used to reliably check which team the user is on, it can only check relative to the user (same/opposite team)
-pub const REGEX_LOBBY: &str =
-    r#"^  Member\[(\d+)] (\[U:\d:\d+])  team = TF_GC_TEAM_(\w+)  type = MATCH_PLAYER\s*$"#;
-
-#[derive(Debug)]
-pub struct LobbyLine {
-    pub steamid: SteamID,
-    pub team: Team,
-}
-
-impl LobbyLine {
-    pub fn parse(caps: &Captures) -> Result<LobbyLine, SteamIDError> {
-        let mut team = Team::Unassigned;
-        match &caps[3] {
-            // TODO - This is not right since teams swap in maps like payload.
-            // This is only temporary until the g15 command is implemented
-            "INVADERS" => team = Team::Blu,
-            "DEFENDERS" => team = Team::Red,
-            _ => {}
-        }
-
-        Ok(LobbyLine {
-            steamid: SteamID::from_steam3(&caps[2])?,
-            team,
-        })
-    }
 }
 
 const INVIS_CHARS: &[char] = &[

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use steamid_ng::SteamID;
 use tokio::sync::mpsc::Sender;
 
 use clap::Parser;
-use io::IOManager;
+use io::{IOManager, Commands};
 use log::{LevelFilter, SetLoggerError};
 use log4rs::append::console::{ConsoleAppender, Target};
 use log4rs::append::file::FileAppender;
@@ -16,7 +16,7 @@ use log4rs::filter::threshold::ThresholdFilter;
 use settings::Settings;
 use state::State;
 
-use crate::io::command_manager::{CMD_STATUS, CMD_TF_LOBBY_DEBUG};
+use crate::io::command_manager::{CMD_STATUS, CMD_G15_DUMPPLAYER};
 
 mod gamefinder;
 mod io;
@@ -140,14 +140,14 @@ async fn main_loop(mut io: IOManager, steam_api_requester: Sender<SteamID>) {
     }
 }
 
-async fn refresh_loop(cmd: Sender<Arc<str>>) {
+async fn refresh_loop(cmd: Sender<Commands>) {
     log::debug!("Entering refresh loop");
     loop {
         State::write_state().server.refresh();
 
         cmd.send(CMD_STATUS.into()).await.unwrap();
         tokio::time::sleep(Duration::from_secs(3)).await;
-        cmd.send(CMD_TF_LOBBY_DEBUG.into()).await.unwrap();
+        cmd.send(CMD_G15_DUMPPLAYER.into()).await.unwrap();
         tokio::time::sleep(Duration::from_secs(3)).await;
         std::thread::sleep(Duration::from_secs(3));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use steamid_ng::SteamID;
 use tokio::sync::mpsc::Sender;
 
 use clap::Parser;
-use io::{IOManager, Commands};
+use io::{Commands, IOManager};
 use log::{LevelFilter, SetLoggerError};
 use log4rs::append::console::{ConsoleAppender, Target};
 use log4rs::append::file::FileAppender;
@@ -16,7 +16,7 @@ use log4rs::filter::threshold::ThresholdFilter;
 use settings::Settings;
 use state::State;
 
-use crate::io::command_manager::{CMD_STATUS, CMD_G15_DUMPPLAYER};
+use crate::io::command_manager::{CMD_G15_DUMPPLAYER, CMD_STATUS};
 
 mod gamefinder;
 mod io;
@@ -120,7 +120,7 @@ async fn main_loop(mut io: IOManager, steam_api_requester: Sender<SteamID>) {
             Ok(output) => {
                 let mut state = State::write_state();
                 state.rcon_state = Ok(());
-                for output in output {
+                if let Some(output) = output {
                     if let Some(new_player) = state.server.handle_io_response(output) {
                         new_players.push(new_player);
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -145,9 +145,9 @@ async fn refresh_loop(cmd: Sender<Commands>) {
     loop {
         State::write_state().server.refresh();
 
-        cmd.send(CMD_STATUS).await.unwrap();
+        cmd.send(Commands::Status).await.unwrap();
         tokio::time::sleep(Duration::from_secs(3)).await;
-        cmd.send(CMD_G15_DUMPPLAYER).await.unwrap();
+        cmd.send(Commands::G15).await.unwrap();
         tokio::time::sleep(Duration::from_secs(3)).await;
         std::thread::sleep(Duration::from_secs(3));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,8 +16,6 @@ use log4rs::filter::threshold::ThresholdFilter;
 use settings::Settings;
 use state::State;
 
-use crate::io::command_manager::{CMD_G15_DUMPPLAYER, CMD_STATUS};
-
 mod gamefinder;
 mod io;
 mod player;

--- a/src/main.rs
+++ b/src/main.rs
@@ -145,9 +145,9 @@ async fn refresh_loop(cmd: Sender<Commands>) {
     loop {
         State::write_state().server.refresh();
 
-        cmd.send(CMD_STATUS.into()).await.unwrap();
+        cmd.send(CMD_STATUS).await.unwrap();
         tokio::time::sleep(Duration::from_secs(3)).await;
-        cmd.send(CMD_G15_DUMPPLAYER.into()).await.unwrap();
+        cmd.send(CMD_G15_DUMPPLAYER).await.unwrap();
         tokio::time::sleep(Duration::from_secs(3)).await;
         std::thread::sleep(Duration::from_secs(3));
     }

--- a/src/player.rs
+++ b/src/player.rs
@@ -61,7 +61,7 @@ pub enum Team {
 
 impl TryFrom<u32> for Team {
     type Error = &'static str;
-    fn try_from(val: u32) -> Result<Self, Self::Error>  {
+    fn try_from(val: u32) -> Result<Self, Self::Error> {
         match val {
             0 => Ok(Team::Unassigned),
             1 => Ok(Team::Spectators),

--- a/src/player.rs
+++ b/src/player.rs
@@ -59,6 +59,19 @@ pub enum Team {
     Blu = 3,
 }
 
+impl TryFrom<u32> for Team {
+    type Error = &'static str;
+    fn try_from(val: u32) -> Result<Self, Self::Error>  {
+        match val {
+            0 => Ok(Team::Unassigned),
+            1 => Ok(Team::Spectators),
+            2 => Ok(Team::Red),
+            3 => Ok(Team::Blu),
+            _ => Err("Not a valid team value"),
+        }
+    }
+}
+
 impl Serialize for Team {
     fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where

--- a/src/server.rs
+++ b/src/server.rs
@@ -8,11 +8,11 @@ use steamid_ng::SteamID;
 
 use crate::{
     io::{
+        g15,
         regexes::{self, ChatMessage, PlayerKill, StatusLine},
         IOOutput,
-        g15,
     },
-    player::{Player, SteamInfo, Team},
+    player::{Player, SteamInfo},
 };
 
 const MAX_HISTORY_LEN: usize = 100;

--- a/tests/test_g15.rs
+++ b/tests/test_g15.rs
@@ -3,8 +3,8 @@ use std::fs;
 pub mod g15;
 
 pub fn read_log(path: &str) -> String {
-    let g15_log = fs::read_to_string(format!("tests/data/{}.log", path))
-        .expect("No g15 log file found?");
+    let g15_log =
+        fs::read_to_string(format!("tests/data/{}.log", path)).expect("No g15 log file found?");
     g15_log
 }
 
@@ -13,7 +13,6 @@ pub fn read_expected(path: &str) -> String {
         .expect("No g15 log file found?");
     g15_expected
 }
-
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Convert commands to an enum type that implements display, implement `TryFrom` on the Team enum, convert RCON command manager to return an `Option<IOOutput>` instead of a `Vec<IOOutput>`