### PR TITLE
implement a native self-managed buf for logwatcher which handles non-…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,6 +302,7 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "clap",
+ "clap_lex",
  "directories-next",
  "log",
  "log4rs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1359,9 +1359,8 @@ dependencies = [
 
 [[package]]
 name = "rcon"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "618babf41c041e7d6f4baf27f6d92434be58c1eb637edac7f9af7900f247417b"
+version = "0.5.2"
+source = "git+https://github.com/MegaAntiCheat/rust-rcon#aef1cb15a4956abbc8de166fb93c6fbca92c532d"
 dependencies = [
  "err-derive",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ clap = { version = "4.3.11", features = ["derive"] }
 directories-next = "2.0.0"
 log = "0.4.19"
 log4rs = "1.2.0"
-rcon = { version = "0.6.0", features = ["rt-tokio"] }
+rcon = { version = "0.5.2", features = ["rt-tokio"], git = "https://github.com/MegaAntiCheat/rust-rcon" }
 regex = "1.8.4"
 serde = { version = "1.0.164", features = ["rc"] }
 serde_json = "1.0.99"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 axum = "0.6.18"
 clap = { version = "4.3.11", features = ["derive"] }
+clap_lex = "0.5.0"
 directories-next = "2.0.0"
 log = "0.4.19"
 log4rs = "1.2.0"

--- a/src/io.rs
+++ b/src/io.rs
@@ -13,7 +13,7 @@ use crate::state::State;
 use self::g15::G15Parser;
 use self::command_manager::CommandManager;
 use self::command_manager::KickReason;
-use self::logwatcher::LogWatcher;
+use self::logwatcher::FileWatcher;
 use self::regexes::ChatMessage;
 use self::regexes::Hostname;
 use self::regexes::Map;
@@ -69,7 +69,7 @@ pub struct IOManager {
     command_recv: Receiver<Commands>,
     command_send: Sender<Commands>,
     command_manager: CommandManager,
-    log_watcher: Option<LogWatcher>,
+    log_watcher: Option<FileWatcher>,
     parser: G15Parser,
     regex_status: Regex,
     regex_chat: Regex,
@@ -147,7 +147,7 @@ impl IOManager {
             self.reopen_log()?;
         }
 
-        while let Some(line) = self.log_watcher.as_mut().unwrap().next_line() {
+        while let Some(line) = self.log_watcher.as_mut().unwrap().get_line() {
             // Match status
             if let Some(caps) = self.regex_status.captures(&line) {
                 match StatusLine::parse(caps) {
@@ -197,7 +197,7 @@ impl IOManager {
         let state = State::read_state();
         let dir = state.settings.get_tf2_directory();
 
-        match LogWatcher::use_directory(dir.into()) {
+        match FileWatcher::use_directory(dir.into()) {
             Ok(lw) => {
                 log::debug!("Successfully opened log file");
                 self.log_watcher = Some(lw);

--- a/src/io.rs
+++ b/src/io.rs
@@ -10,9 +10,9 @@ use tokio::sync::mpsc::Sender;
 
 use crate::state::State;
 
-use self::g15::G15Parser;
 use self::command_manager::CommandManager;
 use self::command_manager::KickReason;
+use self::g15::G15Parser;
 use self::logwatcher::FileWatcher;
 use self::regexes::ChatMessage;
 use self::regexes::Hostname;

--- a/src/io.rs
+++ b/src/io.rs
@@ -12,8 +12,8 @@ use crate::state::State;
 
 use self::command_manager::CommandManager;
 use self::command_manager::KickReason;
+use self::filewatcher::FileWatcher;
 use self::g15::G15Parser;
-use self::logwatcher::FileWatcher;
 use self::regexes::ChatMessage;
 use self::regexes::Hostname;
 use self::regexes::Map;
@@ -28,8 +28,8 @@ use self::regexes::REGEX_MAP;
 use self::regexes::REGEX_PLAYERCOUNT;
 
 pub mod command_manager;
+pub mod filewatcher;
 pub mod g15;
-pub mod logwatcher;
 pub mod regexes;
 
 // Enums

--- a/src/io.rs
+++ b/src/io.rs
@@ -147,7 +147,8 @@ impl IOManager {
             self.reopen_log()?;
         }
 
-        while let Some(line) = self.log_watcher.as_mut().unwrap().get_line() {
+        while let Some(os_line) = self.log_watcher.as_mut().unwrap().get_line() {
+            let line = os_line.to_string_lossy();
             // Match status
             if let Some(caps) = self.regex_status.captures(&line) {
                 match StatusLine::parse(caps) {

--- a/src/io.rs
+++ b/src/io.rs
@@ -147,8 +147,7 @@ impl IOManager {
             self.reopen_log()?;
         }
 
-        while let Some(os_line) = self.log_watcher.as_mut().unwrap().get_line() {
-            let line = os_line.to_string_lossy();
+        while let Some(line) = self.log_watcher.as_mut().unwrap().get_line() {
             // Match status
             if let Some(caps) = self.regex_status.captures(&line) {
                 match StatusLine::parse(caps) {

--- a/src/io/filewatcher.rs
+++ b/src/io/filewatcher.rs
@@ -103,16 +103,13 @@ impl FileWatcher {
 
             let data_str = String::from_utf8_lossy(&data);
             let mut lines: VecDeque<String> = VecDeque::new();
-            let iter = data_str.split('\n');
 
-            for str in iter {
-                if str.is_empty() || str.trim().is_empty() {
-                    continue;
-                }
-                lines.push_back(str.to_string());
-            }
-
-            self.lines_buf = lines;
+            self.lines_buf.extend(
+                data_str
+                    .lines()
+                    .filter(|x| !(x.trim().is_empty()))
+                    .map(str::to_string),
+            );
         }
     }
 

--- a/src/io/logwatcher.rs
+++ b/src/io/logwatcher.rs
@@ -12,7 +12,10 @@ use std::{
 };
 #[cfg(target_os = "linux")]
 mod utf16_upport {
-    use std::os::unix::ffi::OsStringExt;
+    use std::{
+        ffi::OsString,
+        os::unix::ffi::OsStringExt,
+    };
     pub fn from_bytes(buf: &[u8]) -> OsStringExt {
         OsString::from_vec(&buf.to_vec())
     }

--- a/src/io/logwatcher.rs
+++ b/src/io/logwatcher.rs
@@ -11,12 +11,12 @@ use std::{
     time::SystemTime,
 };
 #[cfg(target_os = "linux")]
-mod utf16_upport {
+mod utf16_support {
     use std::{
         ffi::OsString,
         os::unix::ffi::OsStringExt,
     };
-    pub fn from_bytes(buf: &[u8]) -> OsStringExt {
+    pub fn from_bytes(buf: &[u8]) -> OsString {
         OsString::from_vec(&buf.to_vec())
     }
 }

--- a/src/io/logwatcher.rs
+++ b/src/io/logwatcher.rs
@@ -103,11 +103,10 @@ impl FileWatcher {
 
             let data_str = String::from_utf8_lossy(&data);
             let mut lines: VecDeque<String> = VecDeque::new();
-            let iter = data_str.split("\n");
+            let iter = data_str.split('\n');
 
             for str in iter {
-                if str.is_empty() || str.trim().is_empty()
-                {
+                if str.is_empty() || str.trim().is_empty() {
                     continue;
                 }
                 lines.push_back(str.to_string());

--- a/src/io/logwatcher.rs
+++ b/src/io/logwatcher.rs
@@ -9,6 +9,8 @@ use std::{
     string::String,
     time::SystemTime,
 };
+
+/// Used to shuttle data out of read_lines into get_line
 struct ReadMD(Option<SystemTime>, Cursor<Vec<u8>>);
 
 pub struct FileWatcher {
@@ -18,7 +20,8 @@ pub struct FileWatcher {
     pub cpos: u64,
     /// Data from last file read, split on 0xA <u8> bytes
     pub lines_buf: VecDeque<String>,
-    /// epoch time (u64) of the last time this file was read
+    /// system time of the last time this file was read (tracked by `file modified` timestamp,
+    /// will be time of UNIX EPOCH if not implemented by the host OS. Would this ever happen?)
     pub last_read: Option<SystemTime>,
 }
 

--- a/src/io/logwatcher.rs
+++ b/src/io/logwatcher.rs
@@ -17,7 +17,7 @@ mod utf16_support {
         os::unix::ffi::OsStringExt,
     };
     pub fn from_bytes(buf: &[u8]) -> OsString {
-        OsString::from_vec(&buf.to_vec())
+        OsString::from_vec(buf.to_vec())
     }
 }
 


### PR DESCRIPTION
…utf8 better than BufReader.

This is a majority rewrite of `logwatcher.rs`. We implement `FileWatcher` (to be more generic about what this struct does).

FileWatcher implements the same methods for the most part as `LogWatcher`, except it renames `next_line` to `get_line`. Rather than maintaining a ref to the file, we read the whole file, drop old data, and maintain a vector of lines that we havent seen yet.

Thus innately a `get_line` call will, on average, not interface with the underlying `console.log` file.