### PR TITLE
Improve error handling and replace logging with tracing. Refactor and modify filewatcher.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .idea/
 .vscode/
 .env
+*.log

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,9 +92,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.71"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
+checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
 
 [[package]]
 name = "arc-swap"
@@ -300,6 +300,7 @@ checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 name = "client-backend"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "axum",
  "clap",
  "clap_lex",
@@ -313,6 +314,7 @@ dependencies = [
  "serde_yaml 0.9.22",
  "steamid-ng",
  "tappet",
+ "thiserror",
  "tokio",
 ]
 
@@ -1845,18 +1847,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.40"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "a35fc5b8971143ca348fa6df4f024d4d55264f3468c71ad1c2f365b0a4d58c42"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "463fe12d7993d3b327787537ce8dd4dfa058de32fc2b195ef3cde03dc4771e8f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,9 @@ name = "anyhow"
 version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
+dependencies = [
+ "backtrace",
+]
 
 [[package]]
 name = "arc-swap"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,21 +27,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "anstream"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,12 +83,6 @@ checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
 dependencies = [
  "backtrace",
 ]
-
-[[package]]
-name = "arc-swap"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
 
 [[package]]
 name = "arrayref"
@@ -244,21 +223,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "chrono"
-version = "0.4.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
-dependencies = [
- "android-tzdata",
- "iana-time-zone",
- "js-sys",
- "num-traits 0.2.15",
- "time",
- "wasm-bindgen",
- "winapi",
-]
-
-[[package]]
 name = "clap"
 version = "4.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -308,17 +272,18 @@ dependencies = [
  "clap",
  "clap_lex",
  "directories-next",
- "log",
- "log4rs",
  "rcon",
  "regex",
  "serde",
  "serde_json",
- "serde_yaml 0.9.22",
+ "serde_yaml",
  "steamid-ng",
  "tappet",
  "thiserror",
  "tokio",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -342,6 +307,25 @@ name = "core-foundation-sys"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "darling"
@@ -379,17 +363,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "derive-new"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -399,12 +372,6 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
-
-[[package]]
-name = "destructure_traitobject"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c877555693c14d2f84191cfd3ad8582790fc52b5e2274b40b59cf5f5cea25c7"
 
 [[package]]
 name = "directories-next"
@@ -640,7 +607,7 @@ checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -742,12 +709,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
 name = "hyper"
 version = "0.14.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -782,29 +743,6 @@ dependencies = [
  "native-tls",
  "tokio",
  "tokio-native-tls",
-]
-
-[[package]]
-name = "iana-time-zone"
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "wasm-bindgen",
- "windows",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -908,12 +846,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -940,40 +872,14 @@ name = "log"
 version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
-dependencies = [
- "serde",
-]
 
 [[package]]
-name = "log-mdc"
+name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a94d21414c1f4a51209ad204c1776a3d0765002c76c6abcb602a6f09f1e881c7"
-
-[[package]]
-name = "log4rs"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d36ca1786d9e79b8193a68d480a0907b612f109537115c6ff655a3a1967533fd"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
- "anyhow",
- "arc-swap",
- "chrono",
- "derivative",
- "fnv",
- "humantime",
- "libc",
- "log",
- "log-mdc",
- "parking_lot",
- "serde",
- "serde-value",
- "serde_json",
- "serde_yaml 0.8.26",
- "thiserror",
- "thread-id",
- "typemap-ors",
- "winapi",
+ "regex-automata",
 ]
 
 [[package]]
@@ -1010,7 +916,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys",
 ]
 
@@ -1030,6 +936,16 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
 ]
 
 [[package]]
@@ -1198,13 +1114,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "ordered-float"
-version = "2.10.0"
+name = "overload"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7940cf2ca942593318d07fcf2596cdca60a85c9e7fab408a5e21a4f9dcd40d87"
-dependencies = [
- "num-traits 0.2.15",
-]
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
@@ -1409,8 +1322,23 @@ checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.7.2",
 ]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -1557,16 +1485,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-value"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
-dependencies = [
- "ordered-float",
- "serde",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1646,18 +1564,6 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
-dependencies = [
- "indexmap 1.9.3",
- "ryu",
- "serde",
- "yaml-rust",
-]
-
-[[package]]
-name = "serde_yaml"
 version = "0.9.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "452e67b9c20c37fa79df53201dc03839651086ed9bbe92b3ca585ca9fdaa7d85"
@@ -1667,6 +1573,15 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -1869,25 +1784,40 @@ dependencies = [
 ]
 
 [[package]]
-name = "thread-id"
-version = "4.1.0"
+name = "thread_local"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ee93aa2b8331c0fec9091548843f2c90019571814057da3b783f9de09349d73"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
- "libc",
- "redox_syscall 0.2.16",
- "winapi",
+ "cfg-if",
+ "once_cell",
 ]
 
 [[package]]
 name = "time"
-version = "0.1.45"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+checksum = "59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446"
 dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
+ "itoa",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+
+[[package]]
+name = "time-macros"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96ba15a897f3c86766b757e5ac7221554c6750054d74d5b28844fce5fb36a6c4"
+dependencies = [
+ "time-core",
 ]
 
 [[package]]
@@ -1997,7 +1927,30 @@ dependencies = [
  "cfg-if",
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d48f71a791638519505cefafe162606f706c25592e4bde4d97600c0195312e"
+dependencies = [
+ "crossbeam-channel",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -2007,6 +1960,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -2014,15 +1997,6 @@ name = "try-lock"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
-
-[[package]]
-name = "typemap-ors"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68c24b707f02dd18f1e4ccceb9d49f2058c2fb86384ef9972592904d7a28867"
-dependencies = [
- "unsafe-any-ors",
-]
 
 [[package]]
 name = "unicode-bidi"
@@ -2052,15 +2026,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
-name = "unsafe-any-ors"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a303d30665362d9680d7d91d78b23f5f899504d4f08b3c4cf08d055d87c0ad"
-dependencies = [
- "destructure_traitobject",
-]
-
-[[package]]
 name = "unsafe-libyaml"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2082,6 +2047,12 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"
@@ -2113,12 +2084,6 @@ checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"
@@ -2245,15 +2210,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
 name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2326,13 +2282,4 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
-]
-
-[[package]]
-name = "yaml-rust"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
-dependencies = [
- "linked-hash-map",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,13 +92,13 @@ checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
 
 [[package]]
 name = "async-trait"
-version = "0.1.68"
+version = "0.1.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
+checksum = "a564d521dd56509c4c47480d00b80ee55f7e385ae48db5744c67ad50c92d2ebf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.26",
 ]
 
 [[package]]
@@ -224,9 +224,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.3.11"
+version = "4.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1640e5cc7fb47dbb8338fd471b105e7ed6c3cb2aeb00c2e067127ffd3764a05d"
+checksum = "3eab9e8ceb9afdade1ab3f0fd8dbce5b1b2f468ad653baf10e771781b2b67b73"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -235,9 +235,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.3.11"
+version = "4.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c59138d527eeaf9b53f35a77fcc1fad9d883116070c63d5de1c7dc7b00c72b"
+checksum = "9f2763db829349bf00cfc06251268865ed4363b93a943174f638daf3ecdba2cd"
 dependencies = [
  "anstream",
  "anstyle",
@@ -247,14 +247,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.3.2"
+version = "4.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f"
+checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.26",
 ]
 
 [[package]]
@@ -418,7 +418,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.26",
 ]
 
 [[package]]
@@ -432,9 +432,9 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88bffebc5d80432c9b140ee17875ff173a8ab62faad5b257da912bd2f6c1c0a1"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "err-derive"
@@ -566,7 +566,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.26",
 ]
 
 [[package]]
@@ -658,15 +658,6 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "hermit-abi"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -796,7 +787,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi 0.3.2",
+ "hermit-abi",
  "libc",
  "windows-sys",
 ]
@@ -813,16 +804,16 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
- "hermit-abi 0.3.2",
- "rustix 0.38.3",
+ "hermit-abi",
+ "rustix 0.38.4",
  "windows-sys",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "js-sys"
@@ -879,7 +870,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
- "regex-automata",
+ "regex-automata 0.1.10",
 ]
 
 [[package]]
@@ -1046,11 +1037,11 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi",
  "libc",
 ]
 
@@ -1092,7 +1083,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.26",
 ]
 
 [[package]]
@@ -1144,9 +1135,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4b27ab7be369122c218afc2079489cdcb4b517c0a3fc386ff11e1fedfcc2b35"
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "percent-encoding"
@@ -1171,7 +1162,7 @@ checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.26",
 ]
 
 [[package]]
@@ -1218,9 +1209,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.63"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
@@ -1269,9 +1260,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.29"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
+checksum = "5fe8a65d69dd0808184ebb5f836ab526bb259db23c657efa38711b1072ee47f0"
 dependencies = [
  "proc-macro2",
 ]
@@ -1316,13 +1307,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.4"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
+checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.2",
+ "regex-automata 0.3.3",
+ "regex-syntax 0.7.4",
 ]
 
 [[package]]
@@ -1335,6 +1327,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.7.4",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1342,9 +1345,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
+checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
 name = "reqwest"
@@ -1405,9 +1408,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.3"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac5ffa1efe7548069688cd7028f32591853cd7b5b756d41bcffd2353e4fc75b4"
+checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
 dependencies = [
  "bitflags 2.3.3",
  "errno",
@@ -1418,15 +1421,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.12"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "ryu"
-version = "1.0.13"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "same-file"
@@ -1477,29 +1480,29 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.164"
+version = "1.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
+checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.164"
+version = "1.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
+checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.26",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.99"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46266871c240a00b8f503b877622fe33430b3c7d963bdc0f2adc511e54a1eae3"
+checksum = "d03b412469450d4404fe8499a268edd7f8b79fecb074b0d812ad64ca21f4031b"
 dependencies = [
  "itoa",
  "ryu",
@@ -1508,9 +1511,9 @@ dependencies = [
 
 [[package]]
 name = "serde_path_to_error"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b1b6471d7496b051e03f1958802a73f88b947866f5146f329e47e36554f4e55"
+checksum = "4beec8bce849d58d06238cb50db2e1c417cfeafa4c63f692b15c82b7c80f8335"
 dependencies = [
  "itoa",
  "serde",
@@ -1524,7 +1527,7 @@ checksum = "1d89a8107374290037607734c0b73a85db7ed80cae314b3c5791f192a496e731"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.26",
 ]
 
 [[package]]
@@ -1564,9 +1567,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.22"
+version = "0.9.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "452e67b9c20c37fa79df53201dc03839651086ed9bbe92b3ca585ca9fdaa7d85"
+checksum = "da6075b41c7e3b079e5f246eb6094a44850d3a4c25a67c581c80796c80134012"
 dependencies = [
  "indexmap 2.0.0",
  "itoa",
@@ -1604,9 +1607,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "socket2"
@@ -1621,7 +1624,7 @@ dependencies = [
 [[package]]
 name = "steam-language-gen"
 version = "0.1.2"
-source = "git+https://github.com/Bash-09/SteamHelper-rs#f44cccbc5cf85fc28e5698b11ac4cc4a3912b057"
+source = "git+https://github.com/Bash-09/SteamHelper-rs#3b1e462b9a22afcd2acc26edb7ddac1cc35e2f86"
 dependencies = [
  "arrayref",
  "bincode",
@@ -1639,7 +1642,7 @@ dependencies = [
 [[package]]
 name = "steam-language-gen-derive"
 version = "0.1.2"
-source = "git+https://github.com/Bash-09/SteamHelper-rs#f44cccbc5cf85fc28e5698b11ac4cc4a3912b057"
+source = "git+https://github.com/Bash-09/SteamHelper-rs#3b1e462b9a22afcd2acc26edb7ddac1cc35e2f86"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1649,7 +1652,7 @@ dependencies = [
 [[package]]
 name = "steam-protobuf"
 version = "0.1.2"
-source = "git+https://github.com/Bash-09/SteamHelper-rs#f44cccbc5cf85fc28e5698b11ac4cc4a3912b057"
+source = "git+https://github.com/Bash-09/SteamHelper-rs#3b1e462b9a22afcd2acc26edb7ddac1cc35e2f86"
 dependencies = [
  "glob",
  "protobuf",
@@ -1692,9 +1695,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.23"
+version = "2.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59fb7d6d8281a51045d62b8eb3a7d1ce347b76f312af50cd3dc0af39c87c1737"
+checksum = "45c3457aacde3c65315de5031ec191ce46604304d2446e803d71ade03308d970"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1722,7 +1725,7 @@ dependencies = [
 [[package]]
 name = "tappet"
 version = "0.5.0"
-source = "git+https://github.com/Bash-09/SteamHelper-rs#f44cccbc5cf85fc28e5698b11ac4cc4a3912b057"
+source = "git+https://github.com/Bash-09/SteamHelper-rs#3b1e462b9a22afcd2acc26edb7ddac1cc35e2f86"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -1742,7 +1745,7 @@ dependencies = [
 [[package]]
 name = "tappet-derive"
 version = "0.3.2"
-source = "git+https://github.com/Bash-09/SteamHelper-rs#f44cccbc5cf85fc28e5698b11ac4cc4a3912b057"
+source = "git+https://github.com/Bash-09/SteamHelper-rs#3b1e462b9a22afcd2acc26edb7ddac1cc35e2f86"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1780,7 +1783,7 @@ checksum = "463fe12d7993d3b327787537ce8dd4dfa058de32fc2b195ef3cde03dc4771e8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.26",
 ]
 
 [[package]]
@@ -1863,7 +1866,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.26",
 ]
 
 [[package]]
@@ -1950,7 +1953,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.26",
 ]
 
 [[package]]
@@ -2006,9 +2009,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
+checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "unicode-normalization"
@@ -2027,9 +2030,9 @@ checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "unsafe-libyaml"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1865806a559042e51ab5414598446a5871b561d21b6764f2eabb0dd481d880a6"
+checksum = "f28467d3e1d3c6586d8f25fa243f544f5800fec42d97032474e17222c2b75cfa"
 
 [[package]]
 name = "url"
@@ -2112,7 +2115,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.26",
  "wasm-bindgen-shared",
 ]
 
@@ -2146,7 +2149,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.26",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1.0.72"
 axum = "0.6.18"
 clap = { version = "4.3.11", features = ["derive"] }
 clap_lex = "0.5.0"
@@ -19,4 +20,5 @@ serde_json = "1.0.99"
 serde_yaml = "0.9.22"
 steamid-ng = "1.0.0"
 tappet = { git = "https://github.com/Bash-09/SteamHelper-rs" }
+thiserror = "1.0.43"
 tokio = { version = "1.29.1", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,6 @@ axum = "0.6.18"
 clap = { version = "4.3.11", features = ["derive"] }
 clap_lex = "0.5.0"
 directories-next = "2.0.0"
-log = "0.4.19"
-log4rs = "1.2.0"
 rcon = { version = "0.5.2", features = ["rt-tokio"], git = "https://github.com/MegaAntiCheat/rust-rcon" }
 regex = "1.8.4"
 serde = { version = "1.0.164", features = ["rc"] }
@@ -22,3 +20,6 @@ steamid-ng = "1.0.0"
 tappet = { git = "https://github.com/Bash-09/SteamHelper-rs" }
 thiserror = "1.0.43"
 tokio = { version = "1.29.1", features = ["full"] }
+tracing = "0.1.37"
+tracing-appender = "0.2.2"
+tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.72"
+anyhow = { version = "1.0.72", features = ["backtrace"] }
 axum = "0.6.18"
 clap = { version = "4.3.11", features = ["derive"] }
 clap_lex = "0.5.0"

--- a/src/gamefinder.rs
+++ b/src/gamefinder.rs
@@ -5,17 +5,17 @@ use std::{
 
 /// Attempts to open the TF2 directory or locate it if it's not in the expected place
 pub fn locate_tf2_folder() -> Option<PathBuf> {
-    log::debug!("Fetching TF2 Folder");
+    tracing::debug!("Fetching TF2 Folder");
     let tf2_folder: &str = "steamapps/common/Team Fortress 2";
     let libs: Vec<PathBuf> = fetch_libraryfolders();
 
     for lib in libs {
         let mut path = lib.to_path_buf();
         path.push(tf2_folder);
-        log::debug!("Found TF2 Folder: {:?}", path);
+        tracing::debug!("Found TF2 Folder: {:?}", path);
 
         if path.exists() && verify_tf_location(&path) {
-            log::info!("Using TF2 directory: {}", path.to_string_lossy());
+            tracing::info!("Using TF2 directory: {}", path.to_string_lossy());
             return Some(path);
         }
     }
@@ -23,7 +23,7 @@ pub fn locate_tf2_folder() -> Option<PathBuf> {
 }
 
 fn fetch_libraryfolders() -> Vec<PathBuf> {
-    log::debug!("Attempting to open libraryfolders.vdf");
+    tracing::debug!("Attempting to open libraryfolders.vdf");
     const LIBFILE: &str = "libraryfolders.vdf";
     let libraryfolders = fs::read_to_string(Path::join(&find_default_lib(), LIBFILE));
 
@@ -40,11 +40,11 @@ fn fetch_libraryfolders() -> Vec<PathBuf> {
                 }
             }
 
-            log::debug!("Successfully read libraryfolders");
+            tracing::debug!("Successfully read libraryfolders");
             paths
         }
         Err(err) => {
-            log::error!("Failed to read libraryfolders.vdf: {:?}", err);
+            tracing::error!("Failed to read libraryfolders.vdf: {:?}", err);
             Vec::new()
         }
     }
@@ -67,15 +67,15 @@ fn find_default_lib() -> PathBuf {
 }
 
 fn verify_tf_location(lib: &Path) -> bool {
-    log::debug!("Start TF2 Verification of {:?}", lib.to_string_lossy());
+    tracing::debug!("Start TF2 Verification of {:?}", lib.to_string_lossy());
     let gameinfo = "tf/gameinfo.txt";
     let mut path = lib.to_path_buf();
     path.push(gameinfo);
 
     if path.exists() {
-        log::debug!("Passed Verification Check");
+        tracing::debug!("Passed Verification Check");
         return true;
     }
-    log::debug!("Failed Verification Check");
+    tracing::debug!("Failed Verification Check");
     false
 }

--- a/src/gamefinder.rs
+++ b/src/gamefinder.rs
@@ -44,7 +44,7 @@ fn fetch_libraryfolders() -> Vec<PathBuf> {
             paths
         }
         Err(err) => {
-            log::error!("Failed to read libraryfolders.vdf: {}", err);
+            log::error!("Failed to read libraryfolders.vdf: {:?}", err);
             Vec::new()
         }
     }

--- a/src/io.rs
+++ b/src/io.rs
@@ -2,34 +2,21 @@ use anyhow::Context;
 use regex::Regex;
 
 use anyhow::{anyhow, Result};
-use regexes::StatusLine;
-use regexes::REGEX_STATUS;
 use std::fmt::Display;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::mpsc::Receiver;
-use tokio::sync::mpsc::Sender;
+use tokio::sync::mpsc::{Receiver, Sender};
 
 use crate::state::State;
 
-use self::command_manager::CommandManager;
-use self::command_manager::KickReason;
+use self::command_manager::{CommandManager, KickReason};
 use self::filewatcher::FileWatcher;
-use self::g15::G15Parser;
-use self::g15::G15Player;
-use self::regexes::ChatMessage;
-use self::regexes::Hostname;
-use self::regexes::Map;
-use self::regexes::PlayerCount;
-use self::regexes::PlayerKill;
-use self::regexes::ServerIP;
-use self::regexes::REGEX_CHAT;
-use self::regexes::REGEX_HOSTNAME;
-use self::regexes::REGEX_IP;
-use self::regexes::REGEX_KILL;
-use self::regexes::REGEX_MAP;
-use self::regexes::REGEX_PLAYERCOUNT;
+use self::g15::{G15Parser, G15Player};
+use self::regexes::{
+    ChatMessage, Hostname, Map, PlayerCount, PlayerKill, ServerIP, StatusLine, REGEX_CHAT,
+    REGEX_HOSTNAME, REGEX_IP, REGEX_KILL, REGEX_MAP, REGEX_PLAYERCOUNT, REGEX_STATUS,
+};
 
 pub mod command_manager;
 pub mod filewatcher;

--- a/src/io/command_manager.rs
+++ b/src/io/command_manager.rs
@@ -50,13 +50,13 @@ impl CommandManager {
         };
 
         tracing::debug!("Running command \"{}\"", command);
-        match rcon.cmd(command).await.context("Failed to run command") {
-            Ok(out) => Ok(out),
-            Err(e) => {
+        rcon.cmd(command)
+            .await
+            .map_err(|e| {
                 self.rcon = None;
-                Err(e)
-            }
-        }
+                e
+            })
+            .context("Failed to run command")
     }
 
     async fn try_connect(&mut self) -> Result<&mut Connection<TcpStream>> {

--- a/src/io/command_manager.rs
+++ b/src/io/command_manager.rs
@@ -72,8 +72,4 @@ impl CommandManager {
 
         out
     }
-
-    pub fn send_chat_command(message: &str) -> String {
-        format!("say \"{}\"", message)
-    }
 }

--- a/src/io/command_manager.rs
+++ b/src/io/command_manager.rs
@@ -50,7 +50,7 @@ impl CommandManager {
         };
 
         log::debug!("Running command \"{}\"", command);
-        Ok(rcon.cmd(command).await.context("Failed to run command")?)
+        rcon.cmd(command).await.context("Failed to run command")
     }
 
     async fn try_connect(&mut self) -> Result<&mut Connection<TcpStream>> {

--- a/src/io/command_manager.rs
+++ b/src/io/command_manager.rs
@@ -1,12 +1,12 @@
 use std::fmt::Display;
 
+use anyhow::{Context, Result};
 use rcon::Connection;
 use tokio::net::TcpStream;
 
 use crate::state::State;
 
-use super::Commands;
-
+#[allow(dead_code)]
 #[derive(Debug)]
 pub enum KickReason {
     None,
@@ -30,6 +30,7 @@ pub struct CommandManager {
     rcon: Option<Connection<TcpStream>>,
 }
 
+#[allow(dead_code)]
 impl CommandManager {
     pub fn new() -> CommandManager {
         CommandManager { rcon: None }
@@ -39,37 +40,33 @@ impl CommandManager {
         self.rcon.is_some()
     }
 
-    pub async fn try_connect(&mut self) -> Result<(), rcon::Error> {
+    pub async fn run_command(&mut self, command: &str) -> Result<String> {
+        let rcon = if let Some(rcon) = self.rcon.as_mut() {
+            rcon
+        } else {
+            self.try_connect()
+                .await
+                .context("Failed to reconnect to RCon.")?
+        };
+
+        log::debug!("Running command \"{}\"", command);
+        Ok(rcon.cmd(command).await.context("Failed to run command")?)
+    }
+
+    async fn try_connect(&mut self) -> Result<&mut Connection<TcpStream>> {
         let password = State::read_state().settings.get_rcon_password();
 
         log::debug!("Attempting to reconnect to RCon");
         match Connection::connect("127.0.0.1:27015", &password).await {
             Ok(con) => {
                 self.rcon = Some(con);
-                log::debug!("RCon successfully connected");
-                Ok(())
+                log::debug!("RCon reconnected.");
+                Ok(self.rcon.as_mut().expect(""))
             }
             Err(e) => {
                 self.rcon = None;
-                log::debug!("RCon failed to connect: {:?}", e);
-                Err(e)
+                Err(e.into())
             }
         }
-    }
-
-    pub async fn run_command(&mut self, command: &str) -> rcon::Result<String> {
-        if self.rcon.is_none() {
-            self.try_connect().await?;
-        }
-
-        log::debug!("Running command \"{}\"", command);
-        let out = self.rcon.as_mut().unwrap().cmd(command).await;
-
-        if let Err(e) = &out {
-            self.rcon = None;
-            log::debug!("Rcon connection was lost: {}", e);
-        }
-
-        out
     }
 }

--- a/src/io/filewatcher.rs
+++ b/src/io/filewatcher.rs
@@ -24,13 +24,8 @@ pub struct FileWatcher {
 }
 
 impl FileWatcher {
-    pub fn use_directory(mut dir: PathBuf) -> Result<FileWatcher> {
-        dir.push("tf/console.log");
-        FileWatcher::new(dir)
-    }
-
     pub fn new(path: PathBuf) -> Result<FileWatcher> {
-        let file = FileWatcher::open_file(&path)?;
+        let file = FileWatcher::open_file(&path).context("Failed to open file to watch.")?;
         let meta = file
             .metadata()
             .context("File didn't have metadata associated")?;
@@ -93,13 +88,13 @@ impl FileWatcher {
         Ok(())
     }
 
-    pub fn get_line(&mut self) -> Option<String> {
+    /// Return the next
+    pub fn get_line(&mut self) -> Result<Option<String>> {
         if self.lines_buf.is_empty() {
-            if let Err(e) = self.read_new_file_lines() {
-                log::error!("Failed to read log file: {}", e);
-            }
+            self.read_new_file_lines()
+                .context("Failed to read new file lines.")?
         }
 
-        self.lines_buf.pop_front()
+        Ok(self.lines_buf.pop_front())
     }
 }

--- a/src/io/filewatcher.rs
+++ b/src/io/filewatcher.rs
@@ -48,21 +48,21 @@ impl FileWatcher {
             return Ok(());
         }
 
+        let mut start_idx = self.last_size;
+
+        // Reset if file has been remade (i.e. is shorter) and update state
+        if (meta.len() as usize) < self.last_size {
+            start_idx = 0;
+        }
+
+        self.last_size = meta.len() as usize;
+
         // Get new file contents
         let mut file =
             FileWatcher::open_file(&self.file_path).context("Failed to reopen log file")?;
         let mut buff: Vec<u8> = Vec::new();
         let _ = file.read_to_end(&mut buff);
-        let mut start_idx = self.last_size;
 
-        // Reset if file has been remade (i.e. is shorter) and update state
-        if buff.len() < self.last_size {
-            start_idx = 0;
-        }
-
-        self.last_size = buff.len();
-
-        // Get strings
         let data_str = String::from_utf8_lossy(&buff[start_idx..]);
         self.lines_buf.extend(
             data_str

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,7 +49,7 @@ async fn main() {
     let mut settings = match settings {
         Ok(settings) => settings,
         Err(e) => {
-            tracing::error!("Failed to load settings, continuing with defaults: {:?}", e);
+            tracing::warn!("Failed to load settings, continuing with defaults: {:?}", e);
             Settings::default()
         }
     };
@@ -143,9 +143,13 @@ async fn refresh_loop(cmd: Sender<Commands>) {
     loop {
         State::write_state().server.refresh();
 
-        cmd.send(Commands::Status).await.expect("Command loop ded");
+        cmd.send(Commands::Status)
+            .await
+            .expect("communication with main loop from refresh loop");
         tokio::time::sleep(Duration::from_secs(3)).await;
-        cmd.send(Commands::G15).await.expect("Command loop ded");
+        cmd.send(Commands::G15)
+            .await
+            .expect("communication with main loop from refresh loop");
         tokio::time::sleep(Duration::from_secs(3)).await;
         std::thread::sleep(Duration::from_secs(3));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-use std::sync::Arc;
 use std::time::Duration;
 use steamapi::steam_api_loop;
 use steamid_ng::SteamID;
@@ -125,7 +124,7 @@ async fn main_loop(mut io: IOManager, steam_api_requester: Sender<SteamID>) {
                 }
             }
             Err(e) => {
-                State::write_state().rcon_state = Err(e);
+                State::write_state().rcon_state = Err(e.into());
             }
         }
 

--- a/src/player.rs
+++ b/src/player.rs
@@ -1,7 +1,7 @@
 use serde::Serialize;
 use serde_json::Map;
 use std::sync::Arc;
-use steamid_ng::{SteamID, SteamIDError};
+use steamid_ng::SteamID;
 
 use crate::io::regexes::StatusLine;
 
@@ -24,12 +24,9 @@ pub struct Player {
 }
 
 impl Player {
-    pub fn new_from_status(
-        status: &StatusLine,
-        user: Option<&SteamID>,
-    ) -> Result<Player, SteamIDError> {
+    pub fn new_from_status(status: &StatusLine, user: Option<&SteamID>) -> Player {
         let is_self = user.map(|user| user == &status.steamid).unwrap_or(false);
-        Ok(Player {
+        Player {
             name: status.name.clone(),
             steamid: status.steamid,
             is_self,
@@ -37,7 +34,7 @@ impl Player {
             steam_info: None,
             custom_data: serde_json::Value::Object(Map::new()),
             tags: Vec::new(),
-        })
+        }
     }
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -179,7 +179,6 @@ impl Server {
             player.game_info.accounted = true;
             None
         } else {
-            // Since we have already gotten a valid steamid from this status line it is safe to unwrap
             let player = Player::new_from_status(&status, user);
             self.players.insert(status.steamid, player);
             Some(status.steamid)

--- a/src/server.rs
+++ b/src/server.rs
@@ -60,6 +60,7 @@ impl Server {
         // TODO - Maybe move this back into state instead of inside server?
         use IOOutput::*;
         match response {
+            NoOutput => {}
             G15(players) => self.handle_g15_parse(players),
             Status(status) => {
                 return self.add_or_update_player(status, None);
@@ -179,7 +180,7 @@ impl Server {
             None
         } else {
             // Since we have already gotten a valid steamid from this status line it is safe to unwrap
-            let player = Player::new_from_status(&status, user).unwrap();
+            let player = Player::new_from_status(&status, user);
             self.players.insert(status.steamid, player);
             Some(status.steamid)
         }

--- a/src/server.rs
+++ b/src/server.rs
@@ -187,12 +187,12 @@ impl Server {
 
     fn handle_chat(&mut self, chat: ChatMessage) {
         // TODO
-        log::info!("Chat: {:?}", chat);
+        tracing::info!("Chat: {:?}", chat);
     }
 
     fn handle_kill(&mut self, kill: PlayerKill) {
         // TODO
-        log::info!("Kill: {:?}", kill);
+        tracing::info!("Kill: {:?}", kill);
     }
 }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,49 +1,15 @@
 use std::{
-    fmt::Display,
     fs::OpenOptions,
     io::Write,
     path::{Path, PathBuf},
     sync::Arc,
 };
 
+use anyhow::{anyhow, Context, Result};
 use directories_next::ProjectDirs;
 use serde::{Deserialize, Serialize};
 
 use crate::gamefinder;
-
-#[derive(Debug)]
-pub enum Error {
-    IO(std::io::Error),
-    Serde(serde_yaml::Error),
-    NoValidPath,
-}
-
-impl From<std::io::Error> for Error {
-    fn from(value: std::io::Error) -> Self {
-        Self::IO(value)
-    }
-}
-impl From<serde_yaml::Error> for Error {
-    fn from(value: serde_yaml::Error) -> Self {
-        Self::Serde(value)
-    }
-}
-
-impl Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::IO(io) => {
-                write!(f, "IO: {}", io)
-            }
-            Self::Serde(serde) => {
-                write!(f, "Serialize/Deserialize: {}", serde)
-            }
-            Self::NoValidPath => {
-                write!(f, "No valid home directory was found.")
-            }
-        }
-    }
-}
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(default)]
@@ -56,19 +22,22 @@ pub struct Settings {
     port: u16,
 }
 
+#[allow(dead_code)]
 impl Settings {
     /// Attempt to load settings from the user's saved configuration file
-    pub fn load() -> Result<Settings, Error> {
+    pub fn load() -> Result<Settings> {
         match Self::locate_config_file_path() {
             Some(path) => Self::load_from(path),
-            None => Err(Error::NoValidPath),
+            None => Err(anyhow!("No valid home directory could be found.")),
         }
     }
 
     /// Attempt to load settings from a provided configuration file, or just use default config
-    pub fn load_from(path: PathBuf) -> Result<Settings, Error> {
-        let contents = std::fs::read_to_string(&path)?;
-        let mut settings = serde_yaml::from_str::<Settings>(&contents)?;
+    pub fn load_from(path: PathBuf) -> Result<Settings> {
+        let contents =
+            std::fs::read_to_string(&path).context("Failed to load existing config file.")?;
+        let mut settings =
+            serde_yaml::from_str::<Settings>(&contents).context("Failed to parse settings.")?;
         settings.config_path = Some(path);
 
         log::debug!("Successfully loaded settings.");
@@ -76,17 +45,21 @@ impl Settings {
     }
 
     /// Attempt to save the settings back to the loaded configuration file
-    pub fn save(&self) -> Result<(), Error> {
-        if self.config_path.is_none() {
-            return Err(Error::NoValidPath);
-        }
+    pub fn save(&self) -> Result<()> {
+        let config_path = self.config_path.as_ref().context("No config file set.")?;
 
         let mut open_options = OpenOptions::new();
         let mut file = open_options
             .create(true)
             .write(true)
-            .open(self.config_path.as_ref().unwrap())?;
-        write!(&mut file, "{}", serde_yaml::to_string(self)?)?;
+            .open(config_path)
+            .context("Failed to create or open config file.")?;
+        write!(
+            &mut file,
+            "{}",
+            serde_yaml::to_string(self).context("Failed to serialize configuration.")?
+        )
+        .context("Failed to write to config file.")?;
 
         Ok(())
     }
@@ -94,7 +67,7 @@ impl Settings {
     /// Attempt to save the settings, log errors and ignore result
     pub fn save_ok(&self) {
         if let Err(e) = self.save() {
-            log::error!("Failed to save settings: {}", e);
+            log::error!("Failed to save settings: {:?}", e);
             return;
         }
         log::debug!("Settings saved to {:?}", self.config_path);

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -40,7 +40,7 @@ impl Settings {
             serde_yaml::from_str::<Settings>(&contents).context("Failed to parse settings.")?;
         settings.config_path = Some(path);
 
-        log::debug!("Successfully loaded settings.");
+        tracing::debug!("Successfully loaded settings.");
         Ok(settings)
     }
 
@@ -67,10 +67,10 @@ impl Settings {
     /// Attempt to save the settings, log errors and ignore result
     pub fn save_ok(&self) {
         if let Err(e) = self.save() {
-            log::error!("Failed to save settings: {:?}", e);
+            tracing::error!("Failed to save settings: {:?}", e);
             return;
         }
-        log::debug!("Settings saved to {:?}", self.config_path);
+        tracing::debug!("Settings saved to {:?}", self.config_path);
     }
 
     // Setters & Getters

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use std::{
     ops::{Deref, DerefMut},
     sync::{RwLock, RwLockReadGuard, RwLockWriteGuard},
@@ -42,8 +43,8 @@ impl DerefMut for StateWriteLock<'_> {
 
 #[derive(Debug)]
 pub struct State {
-    pub log_file_state: std::io::Result<()>,
-    pub rcon_state: Result<(), rcon::Error>,
+    pub log_file_state: Result<()>,
+    pub rcon_state: Result<()>,
     pub server: Server,
     pub settings: Settings,
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -18,7 +18,7 @@ impl Deref for StateReadLock<'_> {
     type Target = State;
 
     fn deref(&self) -> &Self::Target {
-        self.lock.as_ref().unwrap()
+        self.lock.as_ref().expect("State lock")
     }
 }
 
@@ -30,12 +30,12 @@ impl Deref for StateWriteLock<'_> {
     type Target = State;
 
     fn deref(&self) -> &Self::Target {
-        self.lock.as_ref().unwrap()
+        self.lock.as_ref().expect("State lock")
     }
 }
 impl DerefMut for StateWriteLock<'_> {
     fn deref_mut(&mut self) -> &mut State {
-        self.lock.as_mut().unwrap()
+        self.lock.as_mut().expect("State lock")
     }
 }
 
@@ -51,18 +51,18 @@ pub struct State {
 
 impl State {
     pub fn initialize_state(state: State) {
-        *STATE.write().unwrap() = Some(state);
+        *STATE.write().expect("State lock") = Some(state);
     }
 
     pub fn read_state() -> StateReadLock<'static> {
         StateReadLock {
-            lock: STATE.read().unwrap(),
+            lock: STATE.read().expect("State lock"),
         }
     }
 
     pub fn write_state() -> StateWriteLock<'static> {
         StateWriteLock {
-            lock: STATE.write().unwrap(),
+            lock: STATE.write().expect("State lock"),
         }
     }
 

--- a/src/steamapi.rs
+++ b/src/steamapi.rs
@@ -6,7 +6,7 @@ use tappet::{
     response_types::{
         GetFriendListResponseBase, GetPlayerBansResponseBase, GetPlayerSummariesResponseBase,
     },
-    Executor, ExecutorResponse, SteamAPI,
+    Executor, SteamAPI,
 };
 use tokio::sync::mpsc::Receiver;
 

--- a/src/steamapi.rs
+++ b/src/steamapi.rs
@@ -18,7 +18,7 @@ use crate::{
 /// Enter a loop to wait for steam lookup requests, make those requests from the Steam web API,
 /// and update the state to include that data. Intended to be run inside a new tokio::task
 pub async fn steam_api_loop(mut requests: Receiver<SteamID>, api_key: Arc<str>) {
-    log::debug!("Entering steam api request loop");
+    tracing::debug!("Entering steam api request loop");
 
     let mut client = SteamAPI::new(api_key);
     loop {
@@ -28,7 +28,7 @@ pub async fn steam_api_loop(mut requests: Receiver<SteamID>, api_key: Arc<str>) 
                     .server
                     .insert_steam_info(request, steam_info),
                 Err(e) => {
-                    log::error!("Failed to get player info from SteamAPI: {:?}", e);
+                    tracing::error!("Failed to get player info from SteamAPI: {:?}", e);
                 }
             }
         }
@@ -37,7 +37,7 @@ pub async fn steam_api_loop(mut requests: Receiver<SteamID>, api_key: Arc<str>) 
 
 /// Make a request to the Steam web API for the chosen player and return the important steam info.
 async fn request_steam_info(client: &mut SteamAPI, player: SteamID) -> Result<SteamInfo> {
-    log::debug!("Requesting steam account: {}", u64::from(player));
+    tracing::debug!("Requesting steam account: {}", u64::from(player));
 
     let summary = client
         .get()

--- a/src/web.rs
+++ b/src/web.rs
@@ -20,7 +20,7 @@ pub async fn web_main(port: u16) {
         .route("/mac/history/v1", get(get_history));
 
     let addr = SocketAddr::from(([127, 0, 0, 1], port));
-    log::info!("Starting web server at {addr}");
+    tracing::info!("Starting web server at {addr}");
     axum::Server::bind(&addr)
         .serve(api.into_make_service())
         .await
@@ -35,7 +35,7 @@ async fn root() -> &'static str {
 
 /// API endpoint to retrieve the current server state
 async fn game() -> impl IntoResponse {
-    log::debug!("State requested");
+    tracing::debug!("State requested");
     (
         StatusCode::OK,
         [
@@ -62,7 +62,7 @@ impl Default for Pagination {
 }
 
 async fn get_history(page: Query<Pagination>) -> impl IntoResponse {
-    log::debug!("History requested");
+    tracing::debug!("History requested");
     (
         StatusCode::OK,
         [
@@ -82,5 +82,5 @@ async fn get_history(page: Query<Pagination>) -> impl IntoResponse {
 
 /// API endpoint to mark a player
 async fn mark(Json(_mark): Json<()>) {
-    log::debug!("Mark player requested");
+    tracing::debug!("Mark player requested");
 }

--- a/src/web.rs
+++ b/src/web.rs
@@ -42,7 +42,7 @@ async fn game() -> impl IntoResponse {
             (header::CONTENT_TYPE, "application/json"),
             (header::ACCESS_CONTROL_ALLOW_ORIGIN, "*"),
         ],
-        serde_json::to_string(&State::read_state().server).unwrap(),
+        serde_json::to_string(&State::read_state().server).expect("Serialize game state"),
     )
 }
 
@@ -74,13 +74,13 @@ async fn get_history(page: Query<Pagination>) -> impl IntoResponse {
                 .server
                 .get_history(page.0.from..page.0.to),
         )
-        .unwrap(),
+        .expect("Serialize player history"),
     )
 }
 
 // Mark
 
 /// API endpoint to mark a player
-async fn mark(Json(mark): Json<()>) {
+async fn mark(Json(_mark): Json<()>) {
     log::debug!("Mark player requested");
 }

--- a/tests/test_g15.rs
+++ b/tests/test_g15.rs
@@ -26,7 +26,6 @@ mod tests {
         let log = read_log(path);
         let parser = G15Parser::new();
         let players = parser.parse_g15(&log);
-        // println!("{:?}", players);
         let expected = read_expected(path);
         assert!(expected == format!("{:?}", players));
     }
@@ -37,7 +36,6 @@ mod tests {
         let log = read_log(path);
         let parser = G15Parser::new();
         let players = parser.parse_g15(&log);
-        // println!("{:?}", players);
         let expected = read_expected(path);
         assert!(expected == format!("{:?}", players));
     }
@@ -48,7 +46,6 @@ mod tests {
         let log = read_log(path);
         let parser = G15Parser::new();
         let players = parser.parse_g15(&log);
-        // println!("{:?}", players);
         let expected = read_expected(path);
         assert!(expected == format!("{:?}", players));
     }
@@ -59,7 +56,6 @@ mod tests {
         let log = read_log(path);
         let parser = G15Parser::new();
         let players = parser.parse_g15(&log);
-        // println!("{:?}", players);
         let expected = read_expected(path);
         assert!(expected == format!("{:?}", players));
     }


### PR DESCRIPTION
Most functions returning result now return an `anyhow::Result` with context included about what it was trying to do. Errors are only logged at the outermost scope they are handled at, and they are debug printed (`{:?}`) to include the context. 

All unwraps have been turned into either error propagations or `expect`s.

`Filewatcher` has been heavily refactored to make better use of the new error handling and also to improve code style and conciseness.

Removed any logging crates and replaced them with tracing.