### PR TITLE
update validation schemas for API spec

### DIFF
--- a/data/schemas/validate_playerPut.json
+++ b/data/schemas/validate_playerPut.json
@@ -8,23 +8,18 @@
 		"^[0-9]{17}$": {
 			"type": "object",
 			"required": [
-				"tags",
+				"localVerdict",
 				"customData"
 			],
 			"properties": {
-				"tags": {
-					"title": "Tags",
-					"type": "array",
-					"default": [],
-					"items":{
-						"title": "Items",
-						"type": "string",
-						"default": "",
-						"examples": [
-							"Suspicious"
-						],
-						"pattern": "^.*$"
-					}
+				"localVerdict": {
+					"title": "Localverdict",
+					"type": "string",
+					"default": "None",
+					"examples": [
+						"Cheater"
+					],
+					"pattern": "^.+$"
 				},
 				"customData": {
 					"title": "Customdata",

--- a/data/schemas/validate_playerResponse.json
+++ b/data/schemas/validate_playerResponse.json
@@ -11,6 +11,8 @@
 		"steamInfo",
 		"gameInfo",
 		"customData",
+		"convicted",
+		"localVerdict",
 		"tags"
 	],
 	"properties": {
@@ -307,6 +309,16 @@
 			"$id": "#root/customData",
 			"title": "Customdata",
 			"type": "object"
+		},
+		"localVerdict": {
+			"$id": "#root/localVerdict",
+			"title": "Localverdict",
+			"type": "string"
+		},
+		"convicted": {
+			"$id": "#root/convicted",
+			"title": "convicted",
+			"type": "boolean"
 		},
 		"tags": {
 			"$id": "#root/tags",


### PR DESCRIPTION
Update the validation schemas to account for the addition of the `localVerdict` and `convicted` keys in a player object.