### PR TITLE
steamapi batching

### DIFF
--- a/src/steamapi.rs
+++ b/src/steamapi.rs
@@ -12,7 +12,7 @@ use tappet::{
     Executor, SteamAPI,
 };
 use tokio::sync::mpsc::UnboundedReceiver;
-use tokio::time::{interval, Duration, MissedTickBehavior};
+use tokio::time::{Duration, MissedTickBehavior};
 
 use crate::{
     player::{Friend, SteamInfo},
@@ -118,7 +118,7 @@ async fn request_steam_info(client: &mut SteamAPI, players: Vec<SteamID>) -> Res
     Ok(steam_infos)
 }
 
-async fn request_player_summary(client: &mut SteamAPI, players: &Vec<SteamID>) -> Result<Vec<PlayerSummary>> {
+async fn request_player_summary(client: &mut SteamAPI, players: &[SteamID]) -> Result<Vec<PlayerSummary>> {
     let summaries = client
         .get()
         .ISteamUser()
@@ -163,7 +163,7 @@ async fn request_account_friends(client: &mut SteamAPI, player: SteamID) -> Resu
         .collect())
 }
 
-async fn request_account_bans(client: &mut SteamAPI, players: &Vec<SteamID>) -> Result<Vec<PlayerBans>> {
+async fn request_account_bans(client: &mut SteamAPI, players: &[SteamID]) -> Result<Vec<PlayerBans>> {
     let bans = client
         .get()
         .ISteamUser()

--- a/src/steamapi.rs
+++ b/src/steamapi.rs
@@ -1,4 +1,6 @@
 use std::sync::Arc;
+use std::time::{Duration, Instant};
+use std::collections::VecDeque;
 
 use anyhow::{anyhow, Context, Result};
 use steamid_ng::SteamID;
@@ -16,33 +18,46 @@ use crate::{
     state::State,
 };
 
+const BATCH_INTERVAL: Duration = Duration::from_secs(1);
+const BATCH_SIZE: usize = 100;  // adjust as needed
+
 /// Enter a loop to wait for steam lookup requests, make those requests from the Steam web API,
 /// and update the state to include that data. Intended to be run inside a new tokio::task
 pub async fn steam_api_loop(mut requests: UnboundedReceiver<SteamID>, api_key: Arc<str>) {
     tracing::debug!("Entering steam api request loop");
 
     let mut client = SteamAPI::new(api_key);
+    let mut buffer: VecDeque<SteamID> = VecDeque::new();
+    let mut last_batch_time = Instant::now();
+
     loop {
         if let Some(request) = requests.recv().await {
-            match request_steam_info(&mut client, request).await {
-                Ok(steam_info) => {
-                    State::write_state()
-                        .server
-                        .insert_steam_info(request, steam_info);
+            buffer.push_back(request);
+
+            if last_batch_time.elapsed() > BATCH_INTERVAL || buffer.len() >= BATCH_SIZE {
+                match request_steam_info(&mut client, buffer.drain(..).collect()).await {
+                    Ok(steam_info_map) => {
+                        for (id, steam_info) in steam_info_map {
+                            State::write_state()
+                                .server
+                                .insert_steam_info(id, steam_info);
+                        }
+                    }
+                    Err(e) => {
+                        tracing::error!("Failed to get player info from SteamAPI: {:?}", e);
+                    }
                 }
-                Err(e) => {
-                    tracing::error!("Failed to get player info from SteamAPI: {:?}", e);
-                }
+                last_batch_time = Instant::now();
             }
         }
     }
 }
 
 /// Make a request to the Steam web API for the chosen player and return the important steam info.
-async fn request_steam_info(client: &mut SteamAPI, player: SteamID) -> Result<SteamInfo> {
-    tracing::debug!("Requesting steam account: {}", u64::from(player));
+async fn request_steam_info(client: &mut SteamAPI, players: Vec<SteamID>) -> Result<Vec<(SteamID, SteamInfo)>> {
+    tracing::debug!("Requesting steam accounts: {:?}", players);
 
-    let summary = request_player_summary(client, player).await?;
+    let summaries = request_player_summary(client, &players).await?;
     // let friends = match request_account_friends(client, player).await {
     //     Ok(friends) => friends,
     //     Err(e) => {
@@ -56,46 +71,47 @@ async fn request_steam_info(client: &mut SteamAPI, player: SteamID) -> Result<St
     //         Vec::new()
     //     }
     // };
-    let bans = request_account_bans(client, player).await?;
+    let bans = request_account_bans(client, &players).await?;
 
-    Ok(SteamInfo {
-        account_name: summary.personaname.clone().into(),
-        pfp_url: summary.avatarfull.clone().into(),
-        profile_url: summary.profileurl.clone().into(),
-        pfp_hash: summary.avatarhash.clone().into(),
-        profile_visibility: summary.communityvisibilitystate.into(),
-        time_created: summary.timecreated,
-        country_code: summary.loccountrycode.clone().map(|s| s.into()),
+    let steam_infos = players.into_iter().zip(summaries.into_iter().zip(bans.into_iter()))
+        .map(|(player, (summary, ban))| {
+            let steam_info = SteamInfo {
+                account_name: summary.personaname.clone().into(),
+                pfp_url: summary.avatarfull.clone().into(),
+                profile_url: summary.profileurl.clone().into(),
+                pfp_hash: summary.avatarhash.clone().into(),
+                profile_visibility: summary.communityvisibilitystate.into(),
+                time_created: summary.timecreated,
+                country_code: summary.loccountrycode.clone().map(|s| s.into()),
+                vac_bans: ban.number_of_vac_bans,
+                game_bans: ban.number_of_game_bans,
+                days_since_last_ban: if ban.number_of_vac_bans > 0 || ban.number_of_game_bans > 0 {
+                    Some(ban.days_since_last_ban)
+                } else {
+                    None
+                },
+            };
+            (player, steam_info)
+        })
+        .collect();
 
-        vac_bans: bans.number_of_vac_bans,
-        game_bans: bans.number_of_game_bans,
-        days_since_last_ban: if bans.number_of_vac_bans > 0 || bans.number_of_game_bans > 0 {
-            Some(bans.days_since_last_ban)
-        } else {
-            None
-        },
-        // friends,
-    })
+    Ok(steam_infos)
 }
 
-async fn request_player_summary(client: &mut SteamAPI, player: SteamID) -> Result<PlayerSummary> {
-    let summary = client
+async fn request_player_summary(client: &mut SteamAPI, players: &Vec<SteamID>) -> Result<Vec<PlayerSummary>> {
+    let summaries = client
         .get()
         .ISteamUser()
-        .GetPlayerSummaries(vec![format!("{}", u64::from(player))])
+        .GetPlayerSummaries(players.iter().map(|player| format!("{}", u64::from(*player))).collect())
         .execute()
         .await
         .context("Failed to get player summary from SteamAPI.")?;
-    let mut summary = serde_json::from_str::<GetPlayerSummariesResponseBase>(&summary)
-        .with_context(|| format!("Failed to parse player summary from SteamAPI: {}", &summary))?;
-    if summary.response.players.is_empty() {
-        return Err(anyhow!(
-            "Invalid number of responses from player summary request"
-        ));
-    }
-    Ok(summary.response.players.remove(0))
+    let summaries = serde_json::from_str::<GetPlayerSummariesResponseBase>(&summaries)
+        .with_context(|| format!("Failed to parse player summary from SteamAPI: {}", &summaries))?;
+    Ok(summaries.response.players)
 }
 
+// Needs to be updated to accomodate batched SteamID requests
 #[allow(dead_code)]
 async fn request_account_friends(client: &mut SteamAPI, player: SteamID) -> Result<Vec<Friend>> {
     let friends = client
@@ -127,20 +143,15 @@ async fn request_account_friends(client: &mut SteamAPI, player: SteamID) -> Resu
         .collect())
 }
 
-async fn request_account_bans(client: &mut SteamAPI, player: SteamID) -> Result<PlayerBans> {
+async fn request_account_bans(client: &mut SteamAPI, players: &Vec<SteamID>) -> Result<Vec<PlayerBans>> {
     let bans = client
         .get()
         .ISteamUser()
-        .GetPlayerBans(vec![format!("{}", u64::from(player))])
+        .GetPlayerBans(players.iter().map(|player| format!("{}", u64::from(*player))).collect())
         .execute()
         .await
         .context("Failed to get player bans from SteamAPI")?;
-    let mut bans = serde_json::from_str::<GetPlayerBansResponseBase>(&bans)
+    let bans = serde_json::from_str::<GetPlayerBansResponseBase>(&bans)
         .with_context(|| format!("Failed to parse player bans from SteamAPI: {}", &bans))?;
-    if bans.players.is_empty() {
-        return Err(anyhow!(
-            "Invalid number of responses from account bans request"
-        ));
-    }
-    Ok(bans.players.remove(0))
+    Ok(bans.players)
 }

--- a/src/steamapi.rs
+++ b/src/steamapi.rs
@@ -118,7 +118,6 @@ async fn request_steam_info(client: &mut SteamAPI, players: Vec<SteamID>) -> Res
 }
 
 async fn request_player_summary(client: &mut SteamAPI, players: &Vec<SteamID>) -> Result<Vec<PlayerSummary>> {
-    println!("players: {:?}", players);
     let summaries = client
         .get()
         .ISteamUser()
@@ -128,7 +127,6 @@ async fn request_player_summary(client: &mut SteamAPI, players: &Vec<SteamID>) -
         .context("Failed to get player summary from SteamAPI.")?;
     let summaries = serde_json::from_str::<GetPlayerSummariesResponseBase>(&summaries)
         .with_context(|| format!("Failed to parse player summary from SteamAPI: {}", &summaries))?;
-    println!("summaries: {:?}", summaries);
     Ok(summaries.response.players)
 }
 


### PR DESCRIPTION
Added batching to steam_api_loop, request_steam_info, request_player_summary, and request_account_bans. Skipped request_account_friends because it's currently unused.

I'm not entirely happy with my usage of Instant and Duration (not sure if there's a more performant way to do this), but I was able to get it running in-game and working with the react UI. I'm not the most hardcore Rust dev so there are probably a few more optimizations/design patterns that I'm missing. 

Aimed at #27 