### PR TITLE
reduce file reads in FileWatcher

### DIFF
--- a/src/io/filewatcher.rs
+++ b/src/io/filewatcher.rs
@@ -66,7 +66,7 @@ impl FileWatcher {
         self.last_size = meta.len() as usize;
         
         // Get new file contents
-        self.file.seek(SeekFrom::Start(start_idx as u64))?;
+        // self.file.seek(SeekFrom::Start(start_idx as u64))?;
         let mut buff: Vec<u8> = Vec::new();
         let read_size = self.file.read_to_end(&mut buff)?;
 
@@ -77,9 +77,9 @@ impl FileWatcher {
                 .write(false)
                 .open(&self.file_path)
                 .context("Failed to reopen file.")?;
-            self.file.seek(SeekFrom::Start(start_idx as u64))?;
+            // self.file.seek(SeekFrom::Start(start_idx as u64))?;
             buff.clear();
-            let _ = self.file.read_to_end(&mut buff);
+            let _ = self.file.read_to_end(&mut buff).context("Failed to reopen file.")?;
         }
 
         let data_str = String::from_utf8_lossy(&buff);


### PR DESCRIPTION
The current FileWatcher seems to open and close the log file for every line written to the console. I'm coming from a Python background where opening/reading files ends up being a huge issue, but wasn't sure if it would be the case for Rust. 

With the current implementation, handle_log takes around 7.1 ms after a kill is registered in the console, and this new implementation without new file reads takes around 500 µs.

I haven't been able to test this as much as I want to yet, but I wanted to get some feedback before working on this more. 