### PR TITLE
Fix file read occassionally becoming desynced

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -265,12 +265,12 @@ impl Server {
 
     fn handle_chat(&mut self, chat: ChatMessage) {
         // TODO
-        tracing::info!("Chat: {:?}", chat);
+        tracing::debug!("Chat: {:?}", chat);
     }
 
     fn handle_kill(&mut self, kill: PlayerKill) {
         // TODO
-        tracing::info!("Kill: {:?}", kill);
+        tracing::debug!("Kill: {:?}", kill);
     }
 }
 


### PR DESCRIPTION
The expected size of the console log file is compared with the amount of data read to ensure consistency of the log file, however if data is written in between the time of reading the metadata and file contents then this will be wrong and eventually causes the file to be reopened and read from the start again. (This can be more easily induced by inserting a call to `thread::sleep` in `filewatcher.rs` at line 69).

This merge request removes the comparison against the metadata length and just does a broader check of whether or not it got any data when it was expecting to avoid edge cases like this.