### PR TITLE
parsing for timestamp in load_current_steam_user()

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -119,22 +119,22 @@ impl Settings {
                     return None;
                 };
                 let mut latest_timestamp = 0;
-                let mut latest_user_sid64: Option<String> = None;
+                let mut latest_user_sid64: Option<&str> = None;
         
                 for (user_sid64, user_data_values) in users_obj.iter() {
                     user_data_values.iter()
                         .filter_map(|value| value.get_obj())
                         .for_each(|user_data_obj| {
-                            user_data_obj.get("Timestamp")
+                            if let Some(timestamp) = user_data_obj.get("Timestamp")
                                 .and_then(|timestamp_values| timestamp_values.get(0))
                                 .and_then(|timestamp_vdf| timestamp_vdf.get_str())
                                 .and_then(|timestamp_str| timestamp_str.parse::<i64>().ok())
-                                .map(|timestamp| {
-                                    if timestamp > latest_timestamp {
-                                        latest_timestamp = timestamp;
-                                        latest_user_sid64 = Some(user_sid64.to_string());
-                                    }
-                                });
+                            {
+                                if timestamp > latest_timestamp {
+                                    latest_timestamp = timestamp;
+                                    latest_user_sid64 = Some(user_sid64);
+                                }
+                            }
                         });
                 }
         

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -117,20 +117,19 @@ impl Settings {
                     let mut latest_user_sid64: Option<String> = None;
                 
                     for (user_sid64, user_data_values) in users_obj.iter() {
-                        user_data_values.iter().filter_map(|value| value.get_obj()).for_each(|user_data_obj| {
-                            if let Some(timestamp_values) = user_data_obj.get("Timestamp") {
-                                if let Some(timestamp_vdf) = timestamp_values.get(0) {
-                                    if let Some(timestamp_str) = timestamp_vdf.get_str() {
-                                        if let Ok(timestamp) = timestamp_str.parse::<i64>() {
-                                            if timestamp > latest_timestamp {
-                                                latest_timestamp = timestamp;
-                                                latest_user_sid64 = Some(user_sid64.to_string());
-                                            }
-                                        }
+                        for user_data_obj in user_data_values.iter().filter_map(|value| value.get_obj()) {
+                            if let Some(timestamp_str) = user_data_obj.get("Timestamp")
+                                .and_then(|timestamp_values| timestamp_values.get(0))
+                                .and_then(|timestamp_vdf| timestamp_vdf.get_str()) {
+                                match timestamp_str.parse::<i64>() {
+                                    Ok(timestamp) if timestamp > latest_timestamp => {
+                                        latest_timestamp = timestamp;
+                                        latest_user_sid64 = Some(user_sid64.to_string());
                                     }
+                                    _ => {}
                                 }
                             }
-                        });
+                        }
                     }
                 
     


### PR DESCRIPTION
Not ready for a review yet, but I'll put a draft out that "works".

It works correctly in getting the most recent user even with weird ordering in loginusers.vdf.

Case where this doesn't work: my friend logged in and definitely didn't have the correct launch configs, but the backend gamefinder tracer said they were. 