### PR TITLE
Add previous_names to records

### DIFF
--- a/src/player.rs
+++ b/src/player.rs
@@ -27,6 +27,8 @@ pub struct Player {
     #[serde(rename = "localVerdict")]
     pub local_verdict: Verdict,
     pub convicted: bool,
+    #[serde(rename = "previousNames")]
+    pub previous_names: Vec<String>,
 }
 
 impl Player {
@@ -42,6 +44,7 @@ impl Player {
             tags: Vec::new(),
             local_verdict: Verdict::Player,
             convicted: false,
+            previous_names: Vec::new(),
         }
     }
 
@@ -60,6 +63,7 @@ impl Player {
             tags: Vec::new(),
             local_verdict: Verdict::Player,
             convicted: false,
+            previous_names: Vec::new(),
         })
     }
 
@@ -72,6 +76,7 @@ impl Player {
 
         self.custom_data = record.custom_data;
         self.local_verdict = record.verdict;
+        self.previous_names = record.previous_names;
     }
 
     /// Create a record from the current player
@@ -81,6 +86,7 @@ impl Player {
             steamid: self.steamid,
             custom_data: self.custom_data.clone(),
             verdict: self.local_verdict,
+            previous_names: self.previous_names.clone(),
         }
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,7 +1,7 @@
 use serde::{Serialize, Serializer};
 use std::{
     collections::{HashMap, VecDeque},
-    ops::{Deref, DerefMut, Range},
+    ops::Range,
     sync::Arc,
 };
 use steamid_ng::SteamID;
@@ -13,7 +13,7 @@ use crate::{
         IOOutput,
     },
     player::{Player, SteamInfo},
-    player_records::{PlayerRecord, PlayerRecords},
+    player_records::{PlayerRecord, PlayerRecordLock, PlayerRecords},
 };
 
 const MAX_HISTORY_LEN: usize = 100;
@@ -168,30 +168,22 @@ impl Server {
 
     // Player records
 
-    pub fn has_player_record(&self, steamid: &SteamID) -> bool {
-        self.player_records.records.contains_key(steamid)
+    pub fn has_player_record(&self, steamid: SteamID) -> bool {
+        self.player_records.get_records().contains_key(&steamid)
     }
 
     pub fn insert_player_record(&mut self, record: PlayerRecord) {
-        self.player_records.records.insert(record.steamid, record);
+        self.player_records.insert_record(record);
     }
 
     #[allow(dead_code)]
-    pub fn get_player_record(&self, steamid: &SteamID) -> Option<&PlayerRecord> {
-        self.player_records.records.get(steamid)
+    pub fn get_player_record(&self, steamid: SteamID) -> Option<&PlayerRecord> {
+        self.player_records.get_record(steamid)
     }
 
-    pub fn get_player_record_mut(&mut self, steamid: &SteamID) -> Option<PlayerRecordLock> {
-        if self.player_records.records.contains_key(steamid) {
-            Some(PlayerRecordLock {
-                steamid: *steamid,
-                players: &mut self.players,
-                history: &mut self.player_history,
-                playerlist: &mut self.player_records,
-            })
-        } else {
-            None
-        }
+    pub fn get_player_record_mut(&mut self, steamid: SteamID) -> Option<PlayerRecordLock> {
+        self.player_records
+            .get_record_mut(steamid, &mut self.players, &mut self.player_history)
     }
 
     // Other
@@ -203,14 +195,14 @@ impl Server {
     ) -> Vec<SteamID> {
         let mut new_players = Vec::new();
         for pl in players {
-            if let Some(steamid) = &pl.steamid {
+            if let Some(steamid) = pl.steamid {
                 // Update existing player
-                if let Some(player) = self.players.get_mut(steamid) {
+                if let Some(player) = self.players.get_mut(&steamid) {
                     if let Some(scr) = pl.score {
                         player.game_info.kills = scr;
                     }
-                    if let Some(nam) = pl.name {
-                        player.name = nam;
+                    if let Some(name) = pl.name {
+                        player.name = name;
                     }
                     if let Some(dth) = pl.deaths {
                         player.game_info.deaths = dth;
@@ -226,12 +218,16 @@ impl Server {
                     }
                     player.game_info.accounted = true;
                 } else if let Some(mut player) = Player::new_from_g15(&pl, user) {
-                    if let Some(record) = self.player_records.records.get(steamid) {
+                    if let Some(mut record) = self.get_player_record_mut(steamid) {
+                        if !record.previous_names.contains(&player.name) {
+                            record.previous_names.push(player.name.clone());
+                        }
+
                         player.update_from_record(record.clone());
                     }
 
-                    self.players.insert(*steamid, player);
-                    new_players.push(*steamid);
+                    self.players.insert(steamid, player);
+                    new_players.push(steamid);
                 }
             }
         }
@@ -257,7 +253,11 @@ impl Server {
             // Create and insert new player
             let mut player = Player::new_from_status(&status, user);
 
-            if let Some(record) = self.player_records.records.get(&status.steamid) {
+            if let Some(mut record) = self.get_player_record_mut(status.steamid) {
+                if !record.previous_names.contains(&player.name) {
+                    record.previous_names.push(player.name.clone());
+                }
+
                 player.update_from_record(record.clone());
             }
 
@@ -274,62 +274,6 @@ impl Server {
     fn handle_kill(&mut self, kill: PlayerKill) {
         // TODO
         tracing::debug!("Kill: {:?}", kill);
-    }
-}
-
-pub struct PlayerRecordLock<'a> {
-    playerlist: &'a mut PlayerRecords,
-    players: &'a mut HashMap<SteamID, Player>,
-    history: &'a mut VecDeque<Player>,
-    steamid: SteamID,
-}
-
-impl Deref for PlayerRecordLock<'_> {
-    type Target = PlayerRecord;
-
-    fn deref(&self) -> &Self::Target {
-        self.playerlist
-            .records
-            .get(&self.steamid)
-            .expect("Mutating player record.")
-    }
-}
-
-impl DerefMut for PlayerRecordLock<'_> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.playerlist
-            .records
-            .get_mut(&self.steamid)
-            .expect("Reading player record.")
-    }
-}
-
-// Update all players the server has with the updated record
-impl Drop for PlayerRecordLock<'_> {
-    fn drop(&mut self) {
-        let record = self
-            .playerlist
-            .records
-            .get(&self.steamid)
-            .expect("Reading player record");
-
-        // Update server players and history
-        if let Some(p) = self.players.get_mut(&self.steamid) {
-            p.update_from_record(record.clone());
-        }
-
-        if let Some(p) = self.history.iter_mut().find(|p| p.steamid == self.steamid) {
-            p.update_from_record(record.clone());
-        }
-
-        // Update playerlist
-        if record.is_empty() {
-            self.playerlist.records.remove(&self.steamid);
-        }
-
-        if let Err(e) = self.playerlist.save() {
-            tracing::error!("Failed to save playerlist: {:?}", e);
-        }
     }
 }
 

--- a/src/web.rs
+++ b/src/web.rs
@@ -89,14 +89,14 @@ async fn put_user(users: Json<HashMap<SteamID, UserUpdate>>) -> impl IntoRespons
     let mut state = State::write_state();
     for (k, v) in users.0 {
         // Insert record if it didn't exist
-        if !state.server.has_player_record(&k) {
+        if !state.server.has_player_record(k) {
             state.server.insert_player_record(PlayerRecord::new(k));
         }
 
         // Update record
         let mut record = state
             .server
-            .get_player_record_mut(&k)
+            .get_player_record_mut(k)
             .expect("Mutating player record that was just inserted.");
 
         if let Some(custom_data) = v.custom_data {


### PR DESCRIPTION
Resolves https://github.com/MegaAntiCheat/client-backend/issues/51

Also slightly refactors the `PlayerRecordLock` so it can't accidentally be misused from the server object.