### PR TITLE
Only accept large enough SteamIDs in G15.

### DIFF
--- a/src/io/g15.rs
+++ b/src/io/g15.rs
@@ -131,7 +131,7 @@ pub fn parse_health(caps: Captures, players: &mut [G15Player]) -> Result<()> {
 }
 
 /// `m_iAccountID[3] integer (1505713148)` --> capture groups: `(player idx)` `(variable component of a steamID3 ([U:1:1505713148]))`
-pub const REGEX_I_SID3: &str = r#"^m_iAccountID\[(\d+)\]\s+integer\s+\((\d+)\)$"#;
+pub const REGEX_I_SID3: &str = r#"^m_iAccountID\[(\d+)\]\s+integer\s+\((\d\d\d\d+)\)$"#;
 pub fn parse_sid3(caps: Captures, players: &mut [G15Player]) -> Result<()> {
     let idx: usize = caps[1].parse()?;
     let sid3: u64 = caps[2].parse()?;


### PR DESCRIPTION
(Valve) Bots in servers show up with a steamid starting from 0 or 1 and count up, while the real players usually have like 8+ digits. I just added some extra digits to the regex so anybody with a SteamID < 1000 doesn't get counted in the G15 pass, it does seem to work for filtering out valve bots from showing up but it's a tad hacky. I don't see it being likely that a legitimate account playing has a steamid < 1000, but maybe it's possible.