### PR TITLE
initial struct and import of tf2bd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,6 +286,7 @@ dependencies = [
  "keyvalues-serde",
  "rcon",
  "regex",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ clap_lex = "0.5.0"
 directories-next = "2.0.0"
 rcon = { version = "0.5.2", features = ["rt-tokio"], git = "https://github.com/MegaAntiCheat/rust-rcon" }
 regex = "1.8.4"
+reqwest = { version = "0.11", features = ["blocking", "json"] }
 serde = { version = "1.0.164", features = ["rc"] }
 serde_json = "1.0.99"
 serde_yaml = "0.9.22"

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,9 @@ pub struct Args {
     /// Override the playerlist to use
     #[arg(long)]
     pub playerlist: Option<String>,
+    /// Override the playerlist to use
+    #[arg(long)]
+    pub tfbdlist: Option<String>,
     /// Override the default tf2 directory
     #[arg(short = 'd', long)]
     pub tf2_dir: Option<String>,
@@ -148,6 +151,12 @@ async fn main() {
             playerlist_path
         );
         PlayerRecords::load_from(playerlist_path.into())
+    } else if let Some(tfbdlist_path) = &args.tfbdlist {
+        tracing::info!(
+            "Overrode default playerlist path with provided '{}'",
+            tfbdlist_path
+        );
+        PlayerRecords::load_from_tf2bd_path(tfbdlist_path.into()).await
     } else {
         PlayerRecords::load()
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -156,7 +156,7 @@ async fn main() {
             "Overrode default playerlist path with provided '{}'",
             tfbdlist_path
         );
-        PlayerRecords::load_from_tf2bd_path(tfbdlist_path.into()).await
+        PlayerRecords::load_from_tfbd_path(tfbdlist_path.into()).await
     } else {
         PlayerRecords::load()
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ mod settings;
 mod state;
 mod steamapi;
 mod web;
+mod tf2bd;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,8 +23,8 @@ mod server;
 mod settings;
 mod state;
 mod steamapi;
-mod web;
 mod tfbd;
+mod web;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ mod settings;
 mod state;
 mod steamapi;
 mod web;
-mod tf2bd;
+mod tfbd;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]

--- a/src/player_records.rs
+++ b/src/player_records.rs
@@ -66,14 +66,14 @@ impl PlayerRecords {
         }
         tracing::debug!("Loaded {} records from TFBD", records_map.len());
 
-        let file_path = if let Some(path) = path {
-            path
-        } else {
-            Self::locate_playerlist_file()?
-        };
+        // let file_path = if let Some(path) = path {
+        //     path
+        // } else {
+        //     Self::locate_playerlist_file()?
+        // };
             
         Ok(PlayerRecords {
-            path: file_path,
+            path: Self::locate_playerlist_file()?,
             records: records_map,
         })
     }
@@ -280,10 +280,14 @@ impl From<TfbdPlayerlistEntry> for PlayerRecord {
 
         for attribute in entry.attributes {
             match attribute {
-                TfbdPlayerAttributes::Cheater => verdict = Verdict::Cheater,
+                TfbdPlayerAttributes::Cheater => {
+                    verdict = Verdict::Cheater;
+                    // extra_attributes.push("cheater".to_string());
+                },
                 TfbdPlayerAttributes::Suspicious => {
                     if verdict != Verdict::Cheater {
                         verdict = Verdict::Suspicious;
+                        // extra_attributes.push("suspicious".to_string());
                     }
                 }
                 // Adding extra attributes to a separate vector
@@ -301,7 +305,7 @@ impl From<TfbdPlayerlistEntry> for PlayerRecord {
         // Creating custom data
         let custom_data = if !extra_attributes.is_empty() {
             serde_json::json!({
-                "attributes": extra_attributes,
+                "tfbd": extra_attributes,
             })
         } else {
             serde_json::Value::Null

--- a/src/player_records.rs
+++ b/src/player_records.rs
@@ -47,19 +47,20 @@ impl PlayerRecords {
         Ok(playerlist)
     }
 
-    #[allow(dead_code)]
     pub fn load_from_tf2bd(tf2bd: TF2BotDetectorPlayerListSchema) -> Result<PlayerRecords, ConfigFilesError> {
         let mut records_map: HashMap<SteamID, PlayerRecord> = HashMap::new();
 
-        for player in tf2bd.players {
-            // Convert each TfbdPlayerlistEntry into a PlayerRecord
-            let record: PlayerRecord = player.into();
-            records_map.insert(record.steamid, record);
-        }
+        if let Some(players) = tf2bd.players {
+            for player in players {
+                // Convert each TfbdPlayerlistEntry into a PlayerRecord
+                let record: PlayerRecord = player.into();
+                records_map.insert(record.steamid, record);
+            }
+        } 
 
         // Assuming we don't have the exact path at this point; 
         // you might want to provide or infer the path somehow
-        let path = PathBuf::new(); 
+        let path = Self::locate_playerlist_file()?;
 
         Ok(PlayerRecords {
             path,
@@ -67,26 +68,9 @@ impl PlayerRecords {
         })
     }
 
-    #[allow(dead_code)]
     pub async fn load_from_tf2bd_path(path: PathBuf) -> Result<PlayerRecords, ConfigFilesError> {
-        let mut records_map: HashMap<SteamID, PlayerRecord> = HashMap::new();
-
-        let tf2bd = read_tfbd_json(path).await?;
-
-        for player in tf2bd.players {
-            // Convert each TfbdPlayerlistEntry into a PlayerRecord
-            let record: PlayerRecord = player.into();
-            records_map.insert(record.steamid, record);
-        }
-
-        // Assuming we don't have the exact path at this point; 
-        // you might want to provide or infer the path somehow
-        let path = PathBuf::new(); 
-
-        Ok(PlayerRecords {
-            path,
-            records: records_map,
-        })
+        let content = read_tfbd_json(path).await?;
+        Self::load_from_tf2bd(content)
     }
 
     /// Attempt to save the [Playerlist] to the file it was loaded from

--- a/src/player_records.rs
+++ b/src/player_records.rs
@@ -11,7 +11,9 @@ use steamid_ng::SteamID;
 use crate::{
     player::Player,
     settings::{ConfigFilesError, Settings},
-    tfbd::{TF2BotDetectorPlayerListSchema, TfbdPlayerlistEntry, TfbdPlayerAttributes, read_tfbd_json},
+    tfbd::{
+        read_tfbd_json, TF2BotDetectorPlayerListSchema, TfbdPlayerAttributes, TfbdPlayerlistEntry,
+    },
 };
 
 // PlayerList
@@ -47,7 +49,9 @@ impl PlayerRecords {
         Ok(playerlist)
     }
 
-    pub fn load_from_tf2bd(tf2bd: TF2BotDetectorPlayerListSchema) -> Result<PlayerRecords, ConfigFilesError> {
+    pub fn load_from_tf2bd(
+        tf2bd: TF2BotDetectorPlayerListSchema,
+    ) -> Result<PlayerRecords, ConfigFilesError> {
         let mut records_map: HashMap<SteamID, PlayerRecord> = HashMap::new();
 
         if let Some(players) = tf2bd.players {
@@ -56,10 +60,8 @@ impl PlayerRecords {
                 let record: PlayerRecord = player.into();
                 records_map.insert(record.steamid, record);
             }
-        } 
+        }
 
-        // Assuming we don't have the exact path at this point; 
-        // you might want to provide or infer the path somehow
         let path = Self::locate_playerlist_file()?;
 
         Ok(PlayerRecords {
@@ -176,13 +178,12 @@ impl PlayerRecord {
     }
 }
 
-
 impl From<TfbdPlayerlistEntry> for PlayerRecord {
     fn from(entry: TfbdPlayerlistEntry) -> Self {
         // Extracting steamid
-        let steamid = SteamID::try_from(entry.steamid)
-            .expect("Failed to convert SteamIdFormat to SteamID");
-        
+        let steamid =
+            SteamID::try_from(entry.steamid).expect("Failed to convert SteamIdFormat to SteamID");
+
         // Mapping TFBD attributes to Verdict
         let mut verdict = Verdict::Player;
         let mut extra_attributes = Vec::new();

--- a/src/player_records.rs
+++ b/src/player_records.rs
@@ -49,18 +49,19 @@ impl PlayerRecords {
         Ok(playerlist)
     }
 
-    pub fn load_from_tf2bd(
-        tf2bd: TF2BotDetectorPlayerListSchema,
+    pub fn load_from_tfbd(
+        tfbd: TF2BotDetectorPlayerListSchema,
     ) -> Result<PlayerRecords, ConfigFilesError> {
         let mut records_map: HashMap<SteamID, PlayerRecord> = HashMap::new();
 
-        if let Some(players) = tf2bd.players {
+        if let Some(players) = tfbd.players {
             for player in players {
                 // Convert each TfbdPlayerlistEntry into a PlayerRecord
                 let record: PlayerRecord = player.into();
                 records_map.insert(record.steamid, record);
             }
         }
+        tracing::debug!("Loaded {} records from TFBD", records_map.len());
 
         let path = Self::locate_playerlist_file()?;
 
@@ -70,9 +71,9 @@ impl PlayerRecords {
         })
     }
 
-    pub async fn load_from_tf2bd_path(path: PathBuf) -> Result<PlayerRecords, ConfigFilesError> {
+    pub async fn load_from_tfbd_path(path: PathBuf) -> Result<PlayerRecords, ConfigFilesError> {
         let content = read_tfbd_json(path).await?;
-        Self::load_from_tf2bd(content)
+        Self::load_from_tfbd(content)
     }
 
     /// Attempt to save the [Playerlist] to the file it was loaded from

--- a/src/tf2bd.rs
+++ b/src/tf2bd.rs
@@ -1,0 +1,160 @@
+use std::{
+    fs::File,
+    io::Read,
+    path::PathBuf,
+};
+use reqwest;
+use anyhow::{anyhow, Result};
+use serde::{Deserialize, Serialize};
+
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TF2BotDetectorPlayerListSchema {
+    #[serde(rename = "$schema")]
+    pub schema: String,
+    pub file_info: FileInfo,  // This FileInfo struct is from the previous translation
+    pub players: Vec<TfbdPlayerlistEntry>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TfbdPlayerlistEntry {
+    pub steamid: SteamID,  // This SteamID type is from the previous translation
+    pub attributes: TfbdPlayerAttributesArray,  // This struct is from the previous translation
+    pub proof: Option<Vec<String>>,  // Assuming the array holds strings, adjust if necessary
+    pub last_seen: LastSeen,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LastSeen {
+    pub player_name: Option<String>,
+    pub time: i64,  // Using i64 for the time, assuming it's a UNIX timestamp
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TF2BDDefinitions {
+    pub tfbd_player_attributes: TfbdPlayerAttributes,
+    pub tfbd_player_attributes_array: TfbdPlayerAttributesArray,
+    pub color: Color,
+    pub steamid: SteamID,
+    pub file_info: FileInfo,
+    pub tfbd_text_match: TfbdTextMatch,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum TfbdPlayerAttributes {
+    Cheater,
+    Suspicious,
+    Exploiter,
+    Racist,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TfbdPlayerAttributesArray {
+    #[serde(rename = "type")]
+    pub type_: String,
+    pub unique_items: bool,
+    pub items: Vec<TfbdPlayerlistEntry>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Color {
+    #[serde(rename = "type")]
+    pub type_: String,
+    pub min_items: u8,
+    pub max_items: u8,
+    pub items: ChannelIntensity,
+    #[serde(default)]
+    pub default: Vec<f64>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ChannelIntensity {
+    #[serde(rename = "type")]
+    pub type_: String,
+    pub description: String,
+    pub minimum: f64,
+    pub maximum: f64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum SteamID {
+    StringPattern { type_: String, pattern: String },
+    Integer { type_: String },
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct FileInfo {
+    #[serde(rename = "type")]
+    pub type_: String,
+    pub description: String,
+    pub additional_properties: bool,
+    pub properties: FileInfoProperties,
+    pub required: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct FileInfoProperties {
+    pub authors: Vec<String>,
+    pub title: String,
+    pub description: String,
+    pub update_url: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TfbdTextMatch {
+    #[serde(rename = "type")]
+    pub type_: String,
+    pub additional_properties: bool,
+    pub description: String,
+    pub properties: TextMatchProperties,
+    pub required: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TextMatchProperties {
+    pub mode: TextMatchMode,
+    pub patterns: Vec<String>,
+    pub case_sensitive: Option<bool>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum TextMatchMode {
+    Equal,
+    Contains,
+    StartsWith,
+    EndsWith,
+    Regex,
+    Word,
+}
+
+#[allow(dead_code)]
+async fn fetch_data_from_url(url: &str) -> anyhow::Result<TF2BotDetectorPlayerListSchema> {
+    let response = reqwest::blocking::get(url)?;
+    let data: TF2BotDetectorPlayerListSchema = response.json()?;
+    Ok(data)
+}
+
+#[allow(dead_code)]
+pub async fn read_tfbd_json(path: PathBuf) -> Result<TF2BotDetectorPlayerListSchema, anyhow::Error> {
+    let mut file = File::open(path).expect("Unable to open the file");
+    let mut contents = String::new();
+    file.read_to_string(&mut contents).expect("Unable to read the file");
+    
+    let mut data: TF2BotDetectorPlayerListSchema = serde_json::from_str(&contents)?;
+
+    // If players list is missing and update_url exists, fetch data from that URL
+    if data.players.is_empty() {
+        if let Some(url) = &data.file_info.properties.update_url {
+            if let Ok(updated_data) = fetch_data_from_url(url).await {
+                data = updated_data;
+            } else{
+                return Err(anyhow!("Unable to fetch data from URL"));
+            }
+        }
+    }
+
+    Ok(data)
+}

--- a/src/tfbd.rs
+++ b/src/tfbd.rs
@@ -74,16 +74,28 @@ pub enum TfbdPlayerAttributes {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[allow(dead_code)]
 pub struct Color {
     pub r: u8,
     pub g: u8,
     pub b: u8,
     pub a: u8,
-    #[serde(default)]
-    pub default: Vec<f64>,
+}
+
+#[allow(dead_code)]
+impl Default for Color {
+    fn default() -> Self {
+        Color {
+            r: 1,
+            g: 1,
+            b: 1,
+            a: 1,
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[allow(dead_code)]
 pub struct TfbdTextMatch {
     pub description: String,
     pub properties: TextMatchProperties,
@@ -91,6 +103,7 @@ pub struct TfbdTextMatch {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[allow(dead_code)]
 pub struct TextMatchProperties {
     pub mode: TextMatchMode,
     pub patterns: Vec<String>,
@@ -99,12 +112,19 @@ pub struct TextMatchProperties {
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(untagged)]
+#[allow(dead_code)]
 pub enum TextMatchMode {
+    #[serde(rename = "equal")]
     Equal,
+    #[serde(rename = "contains")]
     Contains,
+    #[serde(rename = "starts_with")]
     StartsWith,
+    #[serde(rename = "ends_with")]
     EndsWith,
+    #[serde(rename = "regex")]
     Regex,
+    #[serde(rename = "word")]
     Word,
 }
 

--- a/src/tfbd.rs
+++ b/src/tfbd.rs
@@ -1,18 +1,15 @@
-use std::{
-    convert::TryFrom,
-    path::PathBuf,
-};
-use tokio::fs::File;
-use tokio::io::AsyncReadExt;
 use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
+use std::{convert::TryFrom, path::PathBuf};
 use steamid_ng::SteamID;
+use tokio::fs::File;
+use tokio::io::AsyncReadExt;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct TF2BotDetectorPlayerListSchema {
     #[serde(rename = "$schema")]
     pub schema: String,
-    pub file_info: Option<FileInfo>, 
+    pub file_info: Option<FileInfo>,
     pub players: Option<Vec<TfbdPlayerlistEntry>>,
 }
 
@@ -24,12 +21,11 @@ pub struct FileInfo {
     pub update_url: Option<String>,
 }
 
-
 #[derive(Debug, Serialize, Deserialize)]
 pub struct TfbdPlayerlistEntry {
-    pub steamid: SteamIdFormat,  
-    pub attributes: Vec<TfbdPlayerAttributes>,  
-    pub proof: Option<Vec<String>>, 
+    pub steamid: SteamIdFormat,
+    pub attributes: Vec<TfbdPlayerAttributes>,
+    pub proof: Option<Vec<String>>,
     pub last_seen: LastSeen,
 }
 
@@ -53,11 +49,11 @@ impl TryFrom<SteamIdFormat> for SteamID {
                         SteamID::from_steam2(&s)
                     })
                     .map_err(|_| "Failed to convert from both steam3 and steam2 formats")
-            },
+            }
             SteamIdFormat::SteamIdInteger(i) => {
                 // Convert the i64 to u64
                 Ok(SteamID::from(i as u64))
-            },
+            }
         }
     }
 }
@@ -65,7 +61,7 @@ impl TryFrom<SteamIdFormat> for SteamID {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct LastSeen {
     pub player_name: Option<String>,
-    pub time: i64, 
+    pub time: i64,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -86,7 +82,6 @@ pub struct Color {
     #[serde(default)]
     pub default: Vec<f64>,
 }
-
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct TfbdTextMatch {
@@ -119,11 +114,15 @@ async fn fetch_data_from_url(url: &str) -> anyhow::Result<TF2BotDetectorPlayerLi
     Ok(data)
 }
 
-pub async fn read_tfbd_json(path: PathBuf) -> Result<TF2BotDetectorPlayerListSchema, anyhow::Error> {
+pub async fn read_tfbd_json(
+    path: PathBuf,
+) -> Result<TF2BotDetectorPlayerListSchema, anyhow::Error> {
     let mut file = File::open(path).await.expect("Unable to open the file");
     let mut contents = String::new();
-    file.read_to_string(&mut contents).await.expect("Unable to read the file");
-    
+    file.read_to_string(&mut contents)
+        .await
+        .expect("Unable to read the file");
+
     let mut data: TF2BotDetectorPlayerListSchema = serde_json::from_str(&contents)?;
 
     // If players list is missing or empty and update_url exists, fetch data from that URL

--- a/src/tfbd.rs
+++ b/src/tfbd.rs
@@ -73,60 +73,6 @@ pub enum TfbdPlayerAttributes {
     Racist,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-#[allow(dead_code)]
-pub struct Color {
-    pub r: u8,
-    pub g: u8,
-    pub b: u8,
-    pub a: u8,
-}
-
-#[allow(dead_code)]
-impl Default for Color {
-    fn default() -> Self {
-        Color {
-            r: 1,
-            g: 1,
-            b: 1,
-            a: 1,
-        }
-    }
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-#[allow(dead_code)]
-pub struct TfbdTextMatch {
-    pub description: String,
-    pub properties: TextMatchProperties,
-    pub required: Vec<String>,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-#[allow(dead_code)]
-pub struct TextMatchProperties {
-    pub mode: TextMatchMode,
-    pub patterns: Vec<String>,
-    pub case_sensitive: Option<bool>,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(untagged)]
-#[allow(dead_code)]
-pub enum TextMatchMode {
-    #[serde(rename = "equal")]
-    Equal,
-    #[serde(rename = "contains")]
-    Contains,
-    #[serde(rename = "starts_with")]
-    StartsWith,
-    #[serde(rename = "ends_with")]
-    EndsWith,
-    #[serde(rename = "regex")]
-    Regex,
-    #[serde(rename = "word")]
-    Word,
-}
 
 async fn fetch_data_from_url(url: &str) -> anyhow::Result<TF2BotDetectorPlayerListSchema> {
     let response = reqwest::get(url).await?;


### PR DESCRIPTION
#50 

Currently models the json schema as structs and handles importing from a file + request if the file includes a link to the actual list. 

TODO: convert list to player_record (and back if possible)

I'm also thinking about if we want to modify the player records such that it reads all json files in a directory rather than one single playerlist in case people want to have different playerlists and organize them, but for now it seems fine to just append to the user's playerlist. 