### PR TITLE
use open crate for autolaunching ui in browser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,6 +284,7 @@ dependencies = [
  "include_dir",
  "keyvalues-parser",
  "keyvalues-serde",
+ "open",
  "rcon",
  "regex",
  "serde",
@@ -855,6 +856,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -863,6 +873,16 @@ dependencies = [
  "hermit-abi",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
 ]
 
 [[package]]
@@ -1136,6 +1156,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
+name = "open"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfabf1927dce4d6fdf563d63328a0a506101ced3ec780ca2135747336c98cef8"
+dependencies = [
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
+
+[[package]]
 name = "openssl"
 version = "0.10.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1213,6 +1244,12 @@ name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "percent-encoding"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ axum = "0.6.18"
 clap = { version = "4.3.11", features = ["derive"] }
 clap_lex = "0.5.0"
 directories-next = "2.0.0"
+open = "5.0.0"
 rcon = { version = "0.5.2", features = ["rt-tokio"], git = "https://github.com/MegaAntiCheat/rust-rcon" }
 regex = "1.8.4"
 serde = { version = "1.0.164", features = ["rc"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,7 @@ pub struct Args {
     #[arg(short, long = "ignore_launch_opts", action=ArgAction::SetTrue, default_value_t=false)]
     pub ignore_launch_options: bool,
     /// Launch the web-ui in the default browser on startup
-    #[arg(long = "autolaunch_ui", action=ArgAction::SetTrue, default_value_t=true)]
+    #[arg(long = "autolaunch_ui", action=ArgAction::SetTrue, default_value_t=false)]
     pub autolaunch_ui: bool,
 }
 
@@ -184,8 +184,10 @@ async fn main() {
         web::web_main(port).await;
     });
 
-    open::that(Path::new(&format!("http://localhost:{}", port)))
+    if args.autolaunch_ui {
+        open::that(Path::new(&format!("http://localhost:{}", port)))
         .expect("Failed to open web browser");
+    }    
 
     // Steam API loop
     let (steam_api_requester, steam_api_receiver) = tokio::sync::mpsc::unbounded_channel();

--- a/src/main.rs
+++ b/src/main.rs
@@ -188,8 +188,9 @@ async fn main() {
     });
 
     if autolaunch_ui {
-        open::that(Path::new(&format!("http://localhost:{}", port)))
-        .expect("Failed to open web browser");
+        if let Err(e) = open::that(Path::new(&format!("http://localhost:{}", port))) {
+            tracing::error!("Failed to open web browser: {:?}", e);
+        }
     }    
 
     // Steam API loop

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use player_records::PlayerRecords;
+use std::path::Path;
 use std::time::Duration;
 use steamapi::steam_api_loop;
 use steamid_ng::SteamID;
@@ -52,6 +53,9 @@ pub struct Args {
     /// Do not panic on detecting missing launch options or failure to read/parse the localconfig.vdf file.
     #[arg(short, long = "ignore_launch_opts", action=ArgAction::SetTrue, default_value_t=false)]
     pub ignore_launch_options: bool,
+    /// Launch the web-ui in the default browser on startup
+    #[arg(long = "autolaunch_ui", action=ArgAction::SetTrue, default_value_t=true)]
+    pub autolaunch_ui: bool,
 }
 
 #[tokio::main]
@@ -179,6 +183,9 @@ async fn main() {
     tokio::spawn(async move {
         web::web_main(port).await;
     });
+
+    open::that(Path::new(&format!("http://localhost:{}", port)))
+        .expect("Failed to open web browser");
 
     // Steam API loop
     let (steam_api_requester, steam_api_receiver) = tokio::sync::mpsc::unbounded_channel();

--- a/src/main.rs
+++ b/src/main.rs
@@ -173,6 +173,9 @@ async fn main() {
         tracing::error!("Failed to save playerlist: {:?}", e);
     }
 
+    // Check autolaunch ui setting before settings is borrowed
+    let autolaunch_ui = args.autolaunch_ui || (&settings).get_autolaunch_ui();
+
     // Initialize State
     State::initialize_state(State::new(settings, playerlist));
     let io = IOManager::new();
@@ -184,7 +187,7 @@ async fn main() {
         web::web_main(port).await;
     });
 
-    if args.autolaunch_ui {
+    if autolaunch_ui {
         open::that(Path::new(&format!("http://localhost:{}", port)))
         .expect("Failed to open web browser");
     }    

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use player_records::PlayerRecords;
+use std::path::Path;
 use std::time::Duration;
 use steamapi::steam_api_loop;
 use steamid_ng::SteamID;
@@ -182,6 +183,9 @@ async fn main() {
     tokio::spawn(async move {
         web::web_main(port).await;
     });
+
+    open::that(Path::new(&format!("http://localhost:{}", port)))
+        .expect("Failed to open web browser");
 
     // Steam API loop
     let (steam_api_requester, steam_api_receiver) = tokio::sync::mpsc::unbounded_channel();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,4 @@
 use player_records::PlayerRecords;
-use std::path::Path;
 use std::time::Duration;
 use steamapi::steam_api_loop;
 use steamid_ng::SteamID;
@@ -183,9 +182,6 @@ async fn main() {
     tokio::spawn(async move {
         web::web_main(port).await;
     });
-
-    open::that(Path::new(&format!("http://localhost:{}", port)))
-        .expect("Failed to open web browser");
 
     // Steam API loop
     let (steam_api_requester, steam_api_receiver) = tokio::sync::mpsc::unbounded_channel();

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -43,6 +43,7 @@ pub struct Settings {
     rcon_password: Arc<str>,
     steam_api_key: Arc<str>,
     port: u16,
+    autolaunch_ui: bool,
     external: serde_json::Value,
     #[serde(skip)]
     override_tf2_dir: Option<PathBuf>,
@@ -276,6 +277,11 @@ impl Settings {
         self.port = port;
         self.save_ok();
     }
+
+    pub fn get_autolaunch_ui(&self) -> bool {
+        self.autolaunch_ui
+    }
+
     pub fn set_steam_api_key(&mut self, key: Arc<str>) {
         self.steam_api_key = key;
         self.save_ok();
@@ -314,6 +320,7 @@ impl Default for Settings {
             rcon_password: "mac_rcon".into(),
             steam_api_key: "YOUR_API_KEY_HERE".into(),
             port: 3621,
+            autolaunch_ui: false,
             override_tf2_dir: None,
             override_rcon_password: None,
             override_steam_api_key: None,

--- a/src/web.rs
+++ b/src/web.rs
@@ -67,6 +67,10 @@ pub async fn web_main(port: u16) {
         .serve(api.into_make_service())
         .await
         .expect("Failed to start web service");
+
+    // Open the web browser
+    open::that(Path::new(&format!("http://localhost:{}", port)))
+        .expect("Failed to open web browser");
 }
 
 async fn ui_redirect() -> impl IntoResponse {

--- a/src/web.rs
+++ b/src/web.rs
@@ -67,10 +67,6 @@ pub async fn web_main(port: u16) {
         .serve(api.into_make_service())
         .await
         .expect("Failed to start web service");
-
-    // Open the web browser
-    open::that(Path::new(&format!("http://localhost:{}", port)))
-        .expect("Failed to open web browser");
 }
 
 async fn ui_redirect() -> impl IntoResponse {


### PR DESCRIPTION
              I'd suggest automatically opening the URL of the UI on start of the backend

_Originally posted by @SammCheese in https://github.com/MegaAntiCheat/client-backend/issues/38#issuecomment-1666749663_

adds arg to autolaunch ui (defaulted to true). Only tested on a windows machine, so if someone with a unix machine could test this i'd appreciate it.