### PR TITLE
Remove static singleton for handling shared state.

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 
-use crate::state::{Shared, State};
+use crate::state::SharedState;
 
 use self::command_manager::{CommandManager, KickReason};
 use self::filewatcher::FileWatcher;
@@ -111,7 +111,7 @@ impl IOManager {
         self.command_send.clone()
     }
 
-    pub async fn handle_waiting_command(&mut self, state: &Shared<State>) -> Result<IOOutput> {
+    pub async fn handle_waiting_command(&mut self, state: &SharedState) -> Result<IOOutput> {
         if let Ok(Some(command)) =
             tokio::time::timeout(Duration::from_millis(50), self.command_recv.recv()).await
         {
@@ -124,7 +124,7 @@ impl IOManager {
     /// Run a command and handle the response from it
     pub async fn handle_command(
         &mut self,
-        state: &Shared<State>,
+        state: &SharedState,
         command: Commands,
     ) -> Result<IOOutput> {
         let resp: String = self
@@ -165,9 +165,9 @@ impl IOManager {
     }
 
     /// Parse all of the new log entries that have been written
-    pub fn handle_log(&mut self, state: &Shared<State>) -> Result<IOOutput> {
+    pub fn handle_log(&mut self, state: &SharedState) -> Result<IOOutput> {
         if self.log_watcher.as_ref().is_none() {
-            let dir = state.read().settings.get_tf2_directory().into();
+            let dir = state.settings.read().get_tf2_directory().into();
             self.reopen_log(dir).context("Failed to reopen log file.")?;
         }
 

--- a/src/io.rs
+++ b/src/io.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 
-use crate::state::State;
+use crate::state::{Shared, State};
 
 use self::command_manager::{CommandManager, KickReason};
 use self::filewatcher::FileWatcher;
@@ -111,21 +111,25 @@ impl IOManager {
         self.command_send.clone()
     }
 
-    pub async fn handle_waiting_command(&mut self) -> Result<IOOutput> {
+    pub async fn handle_waiting_command(&mut self, state: &Shared<State>) -> Result<IOOutput> {
         if let Ok(Some(command)) =
             tokio::time::timeout(Duration::from_millis(50), self.command_recv.recv()).await
         {
-            return self.handle_command(command).await;
+            return self.handle_command(state, command).await;
         }
 
         Ok(IOOutput::NoOutput)
     }
 
     /// Run a command and handle the response from it
-    pub async fn handle_command(&mut self, command: Commands) -> Result<IOOutput> {
+    pub async fn handle_command(
+        &mut self,
+        state: &Shared<State>,
+        command: Commands,
+    ) -> Result<IOOutput> {
         let resp: String = self
             .command_manager
-            .run_command(&format!("{}", command))
+            .run_command(state, &format!("{}", command))
             .await
             .context("Failed to run command")?;
         Ok(match command {
@@ -161,9 +165,10 @@ impl IOManager {
     }
 
     /// Parse all of the new log entries that have been written
-    pub fn handle_log(&mut self) -> Result<IOOutput> {
+    pub fn handle_log(&mut self, state: &Shared<State>) -> Result<IOOutput> {
         if self.log_watcher.as_ref().is_none() {
-            self.reopen_log().context("Failed to reopen log file.")?;
+            let dir = state.read().settings.get_tf2_directory().into();
+            self.reopen_log(dir).context("Failed to reopen log file.")?;
         }
 
         loop {
@@ -225,12 +230,10 @@ impl IOManager {
     }
 
     /// Attempt to reopen the log file with the currently set directory.
-    fn reopen_log(&mut self) -> Result<()> {
-        let state = State::read_state();
-        let mut dir: PathBuf = state.settings.get_tf2_directory().into();
-        dir.push("tf/console.log");
+    fn reopen_log(&mut self, mut tf2_dir: PathBuf) -> Result<()> {
+        tf2_dir.push("tf/console.log");
 
-        match FileWatcher::new(dir) {
+        match FileWatcher::new(tf2_dir) {
             Ok(lw) => {
                 self.log_watcher = Some(lw);
                 tracing::info!("Successfully opened log file.");

--- a/src/io/command_manager.rs
+++ b/src/io/command_manager.rs
@@ -5,7 +5,7 @@ use rcon::Connection;
 use serde::Deserialize;
 use tokio::{net::TcpStream, time::timeout};
 
-use crate::state::{Shared, State};
+use crate::state::SharedState;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -47,11 +47,12 @@ impl CommandManager {
         self.rcon.is_some()
     }
 
-    pub async fn run_command(&mut self, state: &Shared<State>, command: &str) -> Result<String> {
+    pub async fn run_command(&mut self, state: &SharedState, command: &str) -> Result<String> {
         let rcon = if let Some(rcon) = self.rcon.as_mut() {
             rcon
         } else {
-            self.try_connect(&state.read().settings.get_rcon_password())
+            let pwd = state.settings.read().get_rcon_password();
+            self.try_connect(&pwd)
                 .await
                 .context("Failed to reconnect to RCon.")?
         };

--- a/src/player.rs
+++ b/src/player.rs
@@ -59,7 +59,7 @@ impl Player {
             is_self,
             game_info,
             steam_info: None,
-            custom_data: serde_json::Value::default(),
+            custom_data: serde_json::Value::Object(Map::new()),
             tags: Vec::new(),
             local_verdict: Verdict::Player,
             convicted: false,

--- a/src/player_records.rs
+++ b/src/player_records.rs
@@ -120,7 +120,7 @@ impl PlayerRecord {
     pub fn new(steamid: SteamID) -> PlayerRecord {
         PlayerRecord {
             steamid,
-            custom_data: serde_json::Value::default(),
+            custom_data: serde_json::Value::Object(serde_json::Map::new()),
             verdict: Verdict::Player,
             previous_names: Vec::new(),
         }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,41 +1,27 @@
 use anyhow::Result;
-use std::{
-    ops::{Deref, DerefMut},
-    sync::{RwLock, RwLockReadGuard, RwLockWriteGuard},
-};
+use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
+use tokio::sync::mpsc::UnboundedSender;
 
-use crate::{player_records::PlayerRecords, server::Server, settings::Settings};
+use crate::{io::Commands, player_records::PlayerRecords, server::Server, settings::Settings};
 
-// State singleton and lock helpers
+// Struct for shared state and lock helpers
+pub struct Shared<S>(Arc<RwLock<S>>);
 
-static STATE: RwLock<Option<State>> = RwLock::new(None);
-
-pub struct StateReadLock<'a> {
-    lock: RwLockReadGuard<'a, Option<State>>,
-}
-
-impl Deref for StateReadLock<'_> {
-    type Target = State;
-
-    fn deref(&self) -> &Self::Target {
-        self.lock.as_ref().expect("State lock")
+impl<S> Clone for Shared<S> {
+    fn clone(&self) -> Self {
+        Shared(self.0.clone())
     }
 }
 
-pub struct StateWriteLock<'a> {
-    lock: RwLockWriteGuard<'a, Option<State>>,
-}
-
-impl Deref for StateWriteLock<'_> {
-    type Target = State;
-
-    fn deref(&self) -> &Self::Target {
-        self.lock.as_ref().expect("State lock")
+impl<S> Shared<S> {
+    pub fn new(state: S) -> Shared<S> {
+        Shared(Arc::new(RwLock::new(state)))
     }
-}
-impl DerefMut for StateWriteLock<'_> {
-    fn deref_mut(&mut self) -> &mut State {
-        self.lock.as_mut().expect("State lock")
+    pub fn read(&self) -> RwLockReadGuard<S> {
+        self.0.read().expect("State poisoned")
+    }
+    pub fn write(&self) -> RwLockWriteGuard<S> {
+        self.0.write().expect("State poisoned")
     }
 }
 
@@ -44,37 +30,23 @@ impl DerefMut for StateWriteLock<'_> {
 pub struct State {
     pub log_file_state: Result<()>,
     pub rcon_state: Result<()>,
+    pub command_issuer: UnboundedSender<Commands>,
     pub server: Server,
     pub settings: Settings,
 }
 
 impl State {
-    pub fn initialize_state(state: State) {
-        *STATE.write().expect("State lock") = Some(state);
-    }
-
-    pub fn read_state() -> StateReadLock<'static> {
-        StateReadLock {
-            lock: STATE.read().expect("State lock"),
-        }
-    }
-
-    pub fn write_state() -> StateWriteLock<'static> {
-        StateWriteLock {
-            lock: STATE.write().expect("State lock"),
-        }
-    }
-
-    pub fn new(settings: Settings, playerlist: PlayerRecords) -> State {
+    pub fn new(
+        settings: Settings,
+        playerlist: PlayerRecords,
+        command_issuer: UnboundedSender<Commands>,
+    ) -> State {
         State {
             log_file_state: Ok(()),
             rcon_state: Ok(()),
+            command_issuer,
             server: Server::new(playerlist),
             settings,
         }
-    }
-
-    pub fn is_initialized() -> bool {
-        STATE.read().expect("State poisoned").is_some()
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,4 +1,3 @@
-use anyhow::Result;
 use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
 use tokio::sync::mpsc::UnboundedSender;
 
@@ -27,26 +26,23 @@ impl<S> Shared<S> {
 
 // State
 
-pub struct State {
-    pub log_file_state: Result<()>,
-    pub rcon_state: Result<()>,
+#[derive(Clone)]
+pub struct SharedState {
     pub command_issuer: UnboundedSender<Commands>,
-    pub server: Server,
-    pub settings: Settings,
+    pub server: Shared<Server>,
+    pub settings: Shared<Settings>,
 }
 
-impl State {
+impl SharedState {
     pub fn new(
         settings: Settings,
         playerlist: PlayerRecords,
         command_issuer: UnboundedSender<Commands>,
-    ) -> State {
-        State {
-            log_file_state: Ok(()),
-            rcon_state: Ok(()),
+    ) -> SharedState {
+        SharedState {
             command_issuer,
-            server: Server::new(playerlist),
-            settings,
+            server: Shared::new(Server::new(playerlist)),
+            settings: Shared::new(settings),
         }
     }
 }

--- a/src/steamapi.rs
+++ b/src/steamapi.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 use std::collections::VecDeque;
-use std::sync::Arc;
 
 use anyhow::{anyhow, Context, Result};
 use steamid_ng::SteamID;
@@ -14,10 +13,11 @@ use tappet::{
 use tokio::sync::mpsc::UnboundedReceiver;
 use tokio::time::{Duration, MissedTickBehavior};
 
+use crate::server::Server;
 use crate::state::Shared;
 use crate::{
     player::{Friend, SteamInfo},
-    state::State,
+    state::SharedState,
 };
 
 const BATCH_INTERVAL: Duration = Duration::from_millis(500);
@@ -25,10 +25,10 @@ const BATCH_SIZE: usize = 20; // adjust as needed
 
 /// Enter a loop to wait for steam lookup requests, make those requests from the Steam web API,
 /// and update the state to include that data. Intended to be run inside a new tokio::task
-pub async fn steam_api_loop(state: Shared<State>, mut requests: UnboundedReceiver<SteamID>) {
+pub async fn steam_api_loop(state: SharedState, mut requests: UnboundedReceiver<SteamID>) {
     tracing::debug!("Entering steam api request loop");
 
-    let mut client = SteamAPI::new(state.read().settings.get_steam_api_key());
+    let mut client = SteamAPI::new(state.settings.read().get_steam_api_key());
     let mut buffer: VecDeque<SteamID> = VecDeque::new();
     let mut batch_timer = tokio::time::interval(BATCH_INTERVAL);
     batch_timer.set_missed_tick_behavior(MissedTickBehavior::Delay);
@@ -38,25 +38,29 @@ pub async fn steam_api_loop(state: Shared<State>, mut requests: UnboundedReceive
             Some(request) = requests.recv() => {
                 buffer.push_back(request);
                 if buffer.len() >= BATCH_SIZE {
-                    send_batch(&state, &mut client, &mut buffer).await;
+                    send_batch(&state.server, &mut client, &mut buffer).await;
                     batch_timer.reset();  // Reset the timer
                 }
             },
             _ = batch_timer.tick() => {
                 if !buffer.is_empty() {
-                    send_batch(&state, &mut client, &mut buffer).await;
+                    send_batch(&state.server, &mut client, &mut buffer).await;
                 }
             }
         }
     }
 }
 
-async fn send_batch(state: &Shared<State>, client: &mut SteamAPI, buffer: &mut VecDeque<SteamID>) {
+async fn send_batch(
+    server: &Shared<Server>,
+    client: &mut SteamAPI,
+    buffer: &mut VecDeque<SteamID>,
+) {
     match request_steam_info(client, buffer.drain(..).collect()).await {
         Ok(steam_info_map) => {
-            let mut state = state.write();
+            let mut server = server.write();
             for (id, steam_info) in steam_info_map {
-                state.server.insert_steam_info(id, steam_info);
+                server.insert_steam_info(id, steam_info);
             }
         }
         Err(e) => {

--- a/src/web.rs
+++ b/src/web.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use axum::{
-    extract::Query,
+    extract::{Query, State},
     http::{header, StatusCode},
     response::{sse::Event, IntoResponse, Redirect, Sse},
     routing::{get, post, put},
@@ -22,7 +22,7 @@ use tokio_stream::{wrappers::ReceiverStream, Stream};
 use crate::{
     io::Commands,
     player_records::{PlayerRecord, Verdict},
-    state::State,
+    state::{self, Shared},
 };
 
 const HEADERS: [(header::HeaderName, &str); 2] = [
@@ -32,21 +32,10 @@ const HEADERS: [(header::HeaderName, &str); 2] = [
 
 static UI_DIR: Dir = include_dir!("ui");
 
+type AState = axum::extract::State<Shared<state::State>>;
+
 /// Start the web API server
-pub async fn web_main(port: u16) {
-    // Check everything is initialized
-    if !State::is_initialized() {
-        panic!("State is not initialized.");
-    }
-
-    if COMMAND_ISSUER
-        .lock()
-        .expect("Command issuer poisoned.")
-        .is_none()
-    {
-        panic!("Command issuer channel not initialized.");
-    }
-
+pub async fn web_main(state: Shared<state::State>, port: u16) {
     let api = Router::new()
         .route("/", get(ui_redirect))
         .route("/ui", get(ui_redirect))
@@ -59,7 +48,8 @@ pub async fn web_main(port: u16) {
         .route("/mac/game/events/v1", get(get_events))
         .route("/mac/history/v1", get(get_history))
         .route("/mac/commands/v1", post(post_commands))
-        .layer(tower_http::cors::CorsLayer::permissive());
+        .layer(tower_http::cors::CorsLayer::permissive())
+        .with_state(state);
 
     let addr = SocketAddr::from(([127, 0, 0, 1], port));
     tracing::info!("Starting web interface at http://{addr}");
@@ -123,12 +113,12 @@ fn guess_content_type(path: &Path) -> &'static str {
 // Game
 
 /// API endpoint to retrieve the current server state
-async fn get_game() -> impl IntoResponse {
+async fn get_game(State(state): AState) -> impl IntoResponse {
     tracing::debug!("State requested");
     (
         StatusCode::OK,
         HEADERS,
-        serde_json::to_string(&State::read_state().server).expect("Serialize game state"),
+        serde_json::to_string(&state.read().server).expect("Serialize game state"),
     )
 }
 
@@ -156,10 +146,13 @@ struct UserUpdate {
 }
 
 /// Puts a user's details to insert them into the persistent storage for that user.
-async fn put_user(users: Json<HashMap<SteamID, UserUpdate>>) -> impl IntoResponse {
+async fn put_user(
+    State(state): AState,
+    users: Json<HashMap<SteamID, UserUpdate>>,
+) -> impl IntoResponse {
     tracing::debug!("Player updates sent: {:?}", &users);
 
-    let mut state = State::write_state();
+    let mut state = state.write();
     for (k, v) in users.0 {
         // Insert record if it didn't exist
         if !state.server.has_player_record(k) {
@@ -201,10 +194,10 @@ struct Preferences {
 }
 
 /// Get the current preferences
-async fn get_prefs() -> impl IntoResponse {
+async fn get_prefs(State(state): AState) -> impl IntoResponse {
     tracing::debug!("Preferences requested.");
 
-    let state = State::read_state();
+    let state = state.read();
     let prefs = Preferences {
         internal: Some(InternalPreferences {
             tf2_directory: Some(state.settings.get_tf2_directory().to_string_lossy().into()),
@@ -222,10 +215,10 @@ async fn get_prefs() -> impl IntoResponse {
 }
 
 /// Puts any preferences to be updated
-async fn put_prefs(prefs: Json<Preferences>) -> impl IntoResponse {
+async fn put_prefs(State(state): AState, prefs: Json<Preferences>) -> impl IntoResponse {
     tracing::debug!("Preferences updates sent.");
 
-    let mut state = State::write_state();
+    let mut state = state.write();
     let settings = &mut state.settings;
 
     if let Some(internal) = prefs.0.internal {
@@ -285,43 +278,34 @@ impl Default for Pagination {
 
 /// Gets a historical record of the last (up to) 100 players that the user has
 /// been on servers with.
-async fn get_history(page: Query<Pagination>) -> impl IntoResponse {
+async fn get_history(State(state): AState, page: Query<Pagination>) -> impl IntoResponse {
     tracing::debug!("History requested");
     (
         StatusCode::OK,
         HEADERS,
-        serde_json::to_string(
-            &State::read_state()
-                .server
-                .get_history(page.0.from..page.0.to),
-        )
-        .expect("Serialize player history"),
+        serde_json::to_string(&state.read().server.get_history(page.0.from..page.0.to))
+            .expect("Serialize player history"),
     )
 }
 
 // Commands
-
-static COMMAND_ISSUER: Mutex<Option<UnboundedSender<Commands>>> = Mutex::new(None);
-
-pub async fn init_command_issuer(cmd_issuer: UnboundedSender<Commands>) {
-    *COMMAND_ISSUER.lock().expect("Command issuer mutex") = Some(cmd_issuer);
-}
 
 #[derive(Deserialize, Debug)]
 struct RequestedCommands {
     commands: Vec<Commands>,
 }
 
-async fn post_commands(commands: Json<RequestedCommands>) -> impl IntoResponse {
+async fn post_commands(
+    State(state): AState,
+    commands: Json<RequestedCommands>,
+) -> impl IntoResponse {
     tracing::debug!("Commands sent: {:?}", commands);
 
-    let command_issuer = COMMAND_ISSUER.lock().expect("Command issuer mutex");
-    let cmd = command_issuer
-        .as_ref()
-        .expect("Command issuer should be initialised");
-
+    let command_issuer = &state.read().command_issuer;
     for command in commands.0.commands {
-        cmd.send(command).expect("Sending command from web API.");
+        command_issuer
+            .send(command)
+            .expect("Sending command from web API.");
     }
 
     (StatusCode::OK, HEADERS)


### PR DESCRIPTION
The Singleton isn't a very idiomatic pattern in Rust and brings a number of inconveniences, e.g. having to keep an `Option` to actually initialize the state and then unwrapping it every time it's accessed. Removing the singleton and passing around state that is guaranteed to be initialized prevents accidentally accessing it before it's been initialized and removes the associated unwrapping, and also makes it easier to test (if we actually decided to write any tests lol).

I also decided to break the state into it's inner `server` and `settings` components, and added the command channel to it, so they can be accessed individually as they rarely both need to be accessed at once. Since the state struct is just 3 pointers by itself now it is also cheap and easy to clone to where it's needed (mainly when spawning a new tokio task).