### PR TITLE
Don't override settings if they failed to load

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use player_records::PlayerRecords;
-use std::path::Path;
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 use steamapi::steam_api_loop;
 use steamid_ng::SteamID;
@@ -8,7 +9,7 @@ use tokio::sync::mpsc::UnboundedSender;
 use clap::{ArgAction, Parser};
 use io::{Commands, IOManager};
 use launchoptions::LaunchOptions;
-use settings::Settings;
+use settings::{ConfigFilesError, Settings};
 use state::SharedState;
 use tappet::SteamAPI;
 use tracing_appender::non_blocking::WorkerGuard;
@@ -159,27 +160,35 @@ fn main() {
     let port = settings.get_port();
 
     // Playerlist
-    let playerlist = if let Some(playerlist_path) = &args.playerlist {
-        tracing::info!(
-            "Overrode default playerlist path with provided '{}'",
-            playerlist_path
-        );
-        PlayerRecords::load_from(playerlist_path.into())
-    } else {
-        PlayerRecords::load()
-    };
+    let playerlist_path: PathBuf = args
+        .playerlist
+        .as_ref()
+        .map(|i| Ok(i.into()))
+        .unwrap_or(PlayerRecords::locate_playerlist_file()).map_err(|e| {
+            tracing::error!("Could not find a suitable location for the playerlist: {} \nPlease specify a file path manually with --playerlist otherwise information may not be saved.", e); 
+        }).unwrap_or(PathBuf::from("playerlist.json"));
 
-    let playerlist = match playerlist {
-        Ok(playerlist) => {
-            tracing::info!("Successfully loaded playerlist.");
+    let playerlist = match PlayerRecords::load_from(playerlist_path) {
+        Ok(playerlist) => playerlist,
+        Err(ConfigFilesError::Json(path, e)) => {
+            tracing::error!("{} could not be loaded: {:?}", path, e);
+            tracing::error!(
+                "Please resolve any issues or remove the file, otherwise data may be lost."
+            );
+            panic!("Failed to load playerlist")
+        }
+        Err(ConfigFilesError::IO(path, e)) if e.kind() == ErrorKind::NotFound => {
+            tracing::warn!("Could not locate {}, creating new playerlist.", &path);
+            let mut playerlist = PlayerRecords::default();
+            playerlist.set_path(path.into());
             playerlist
         }
         Err(e) => {
-            tracing::warn!(
-                "Failed to load playerlist, creating new playerlist: {:?}",
-                e
+            tracing::error!("Could not load playerlist: {:?}", e);
+            tracing::error!(
+                "Please resolve any issues or remove the file, otherwise data may be lost."
             );
-            PlayerRecords::default()
+            panic!("Failed to load playerlist")
         }
     };
 

--- a/src/player_records.rs
+++ b/src/player_records.rs
@@ -50,6 +50,16 @@ impl PlayerRecords {
         Ok(())
     }
 
+    /// Attempt to save the [Playerlist], log errors and ignore result
+    pub fn save_ok(&self) {
+        if let Err(e) = self.save() {
+            tracing::error!("Failed to save playerlist: {:?}", e);
+            return;
+        }
+        // this will never fail to unwrap because the above error would have occured first and broken control flow.
+        tracing::debug!("Playerlist saved to {:?}", self.path);
+    }
+
     pub fn set_path(&mut self, path: PathBuf) {
         self.path = path;
     }

--- a/src/player_records.rs
+++ b/src/player_records.rs
@@ -6,6 +6,7 @@ use std::{
 
 use anyhow::Context;
 use serde::{Deserialize, Serialize};
+use serde_json::Map;
 use steamid_ng::SteamID;
 
 use crate::{
@@ -23,11 +24,6 @@ pub struct PlayerRecords {
 }
 
 impl PlayerRecords {
-    /// Attempt to load the [Playerlist] from the default file
-    pub fn load() -> Result<PlayerRecords, ConfigFilesError> {
-        Self::load_from(Self::locate_playerlist_file()?)
-    }
-
     /// Attempt to load the [Playerlist] from the provided file
     pub fn load_from(path: PathBuf) -> Result<PlayerRecords, ConfigFilesError> {
         let contents = std::fs::read_to_string(&path)
@@ -52,6 +48,10 @@ impl PlayerRecords {
         std::fs::write(&self.path, contents)
             .map_err(|e| ConfigFilesError::IO(self.path.to_string_lossy().into(), e))?;
         Ok(())
+    }
+
+    pub fn set_path(&mut self, path: PathBuf) {
+        self.path = path;
     }
 
     pub fn insert_record(&mut self, record: PlayerRecord) {
@@ -85,7 +85,7 @@ impl PlayerRecords {
         }
     }
 
-    fn locate_playerlist_file() -> Result<PathBuf, ConfigFilesError> {
+    pub fn locate_playerlist_file() -> Result<PathBuf, ConfigFilesError> {
         Settings::locate_config_directory().map(|dir| dir.join("playerlist.json"))
     }
 }
@@ -110,6 +110,7 @@ impl Default for PlayerRecords {
 pub struct PlayerRecord {
     #[serde(skip)]
     pub steamid: SteamID,
+    #[serde(default = "default_custom_data")]
     pub custom_data: serde_json::Value,
     pub verdict: Verdict,
     #[serde(default)]
@@ -147,6 +148,10 @@ impl PlayerRecord {
                     .unwrap_or(false)
         }
     }
+}
+
+fn default_custom_data() -> serde_json::Value {
+    serde_json::Value::Object(Map::new())
 }
 
 /// What a player is marked as in the personal playerlist


### PR DESCRIPTION
Previously if the playerlist failed to load it would just continue with defaults, even if it was failing to just parse the data. This usually shouldn't be a problem but if someone accidentally messes up the file somehow and if fails to load, running the program again would override the playerlist file with an empty one, immediately losing the data and giving no chance to reconcile it.

In this branch, failing to load the playerlist will cause an error and alert the user, giving them a chance to fix the problems or otherwise backup their data by moving the file somewhere else.

~~The issue is less prevalent for the settings/config, individual fields can be deleted if they get screwed up from manually editing the file, but that usually shouldn't happen and the user can easily fix it so I'm happy to leave it.~~
*The configuration could still be cleared if trying to load a config that doesn't exist, so I've fixed that in here as well.