### PR TITLE
Make launch options regex more general (capture %command% patterns)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .vscode/
 .env
 *.log
+bundle/

--- a/src/launchoptions.rs
+++ b/src/launchoptions.rs
@@ -81,7 +81,7 @@ impl LaunchOptionsV2 {
             }
         }
 
-        let launch_options_regex = Regex::new(r#"\t{6}"LaunchOptions"\t{2}"([(\-\w)\s]*)""#)
+        let launch_options_regex = Regex::new(r#"\t{6}"LaunchOptions"\t{2}"([(\-\w\%\!\@\^\&)\s]*)""#)
             .expect("Constructing LaunchOptions regex");
 
         Ok(LaunchOptionsV2 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,7 +114,8 @@ async fn main() {
                 tracing::error!("Missing launch options: {:?}", missing_opts);
                 if !(args.ignore_launch_options) {
                     panic!(
-                        "Missing required launch options in TF2 for MAC to function. Aborting..."
+                        "Missing required launch options in TF2 for MAC to function. Aborting...\n
+                        (Add the command-line argument '--ignore_launch_opts' to ignore this)."
                     );
                 }
             } else {


### PR DESCRIPTION
- Fix for issue #69 

Hints about the `--ignore_launch_opts` in error message related to this.