### PR TITLE
Add mac/playerlist/v1 API endpoint.

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -172,6 +172,10 @@ impl Server {
         self.player_records.records.contains_key(steamid)
     }
 
+    pub fn get_player_records(&self) -> &PlayerRecords {
+        &self.player_records
+    }
+
     pub fn insert_player_record(&mut self, record: PlayerRecord) {
         self.player_records.records.insert(record.steamid, record);
     }

--- a/src/web.rs
+++ b/src/web.rs
@@ -37,6 +37,7 @@ pub async fn web_main(port: u16) {
         .route("/mac/pref/v1", put(put_prefs))
         .route("/mac/game/events/v1", get(get_events))
         .route("/mac/history/v1", get(get_history))
+        .route("/mac/playerlist/v1", get(get_playerlist))
         .layer(tower_http::cors::CorsLayer::permissive());
 
     let addr = SocketAddr::from(([127, 0, 0, 1], port));
@@ -223,5 +224,20 @@ async fn get_history(page: Query<Pagination>) -> impl IntoResponse {
                 .get_history(page.0.from..page.0.to),
         )
         .expect("Serialize player history"),
+    )
+}
+
+/// Gets the Serde serialised PlayerRecords object from the current state server object.
+async fn get_playerlist() -> impl IntoResponse {
+    tracing::debug!("Playerlist requested");
+    (
+        StatusCode::OK,
+        HEADERS,
+        serde_json::to_string(
+            &State::read_state()
+                .server
+                .get_player_records()
+        )
+        .expect("Serialize player records")
     )
 }


### PR DESCRIPTION
Add an API endpoint to dump the `PlayerRecords` object, useful for verifying if a player exists in the on-disk data store.

Test on Windows with:
```ps
Invoke-RestMethod -Uri http://127.0.0.1:3621/mac/playerlist/v1 -OutFile test-request.json 
``` 

Test on Linux with:
```bash
curl http://127.0.0.1:3621/mac/playerlist/v1 -H "Accept: application/json"
```

