### PR TITLE
Move the "disconnected" into the player's status

### DIFF
--- a/src/player.rs
+++ b/src/player.rs
@@ -236,7 +236,10 @@ impl GameInfo {
 
     pub(crate) fn acknowledge(&mut self) {
         self.last_seen = 0;
-        self.state = PlayerState::Active;
+
+        if self.state == PlayerState::Disconnected {
+            self.state = PlayerState::Spawning;
+        }
     }
 
     pub(crate) fn should_prune(&self) -> bool {

--- a/src/player.rs
+++ b/src/player.rs
@@ -97,6 +97,7 @@ impl Player {
 pub enum PlayerState {
     Active,
     Spawning,
+    Disconnected,
 }
 
 // Team
@@ -190,8 +191,6 @@ pub struct GameInfo {
     pub state: PlayerState,
     pub kills: u32,
     pub deaths: u32,
-    pub disconnected: bool,
-
     #[serde(skip)]
     /// How many cycles has passed since the player has been seen
     last_seen: u32,
@@ -208,7 +207,6 @@ impl GameInfo {
             state: PlayerState::Active,
             kills: g15.score.unwrap_or(0),
             deaths: g15.deaths.unwrap_or(0),
-            disconnected: false,
             last_seen: 0,
         })
     }
@@ -223,8 +221,6 @@ impl GameInfo {
             state: status.state,
             kills: 0,
             deaths: 0,
-            disconnected: false,
-
             last_seen: 0,
         }
     }
@@ -234,13 +230,13 @@ impl GameInfo {
 
         self.last_seen += 1;
         if self.last_seen > DISCONNECTED_THRESHOLD {
-            self.disconnected = true;
+            self.state = PlayerState::Disconnected;
         }
     }
 
     pub(crate) fn acknowledge(&mut self) {
         self.last_seen = 0;
-        self.disconnected = false;
+        self.state = PlayerState::Active;
     }
 
     pub(crate) fn should_prune(&self) -> bool {


### PR DESCRIPTION
This solves https://github.com/MegaAntiCheat/client-backend/issues/65. Tested and it seems to work just fine.
The interfaces in https://github.com/MegaAntiCheat/MegaAntiCheat-UI would probably have to be modified to reflect the change, though I'm not a web dev.

I have no clue how the file that it's parsing from looks like, so I don't know if I have to reflect the change here or something.
https://github.com/MegaAntiCheat/client-backend/blob/79b8a2c931b79fbb9dac572dab5f45c2b8b4eefe/src/io/regexes.rs#L142-L145