### PR TITLE
Friends list retrieval via Steam API

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use args::Args;
 use clap::Parser;
+use crate::player_records::Verdict;
 use include_dir::{include_dir, Dir};
 use player_records::PlayerRecords;
 use server::Server;
@@ -155,7 +156,7 @@ fn main() {
                 steam_api.api_loop().await;
             });
 
-            // Request friends
+            // Request friends of user
             if let Some(user) = settings.get_steam_user() {
                 let steam_api_key = settings.get_steam_api_key().to_string();
                 let mut client = SteamAPI::new(steam_api_key);
@@ -227,8 +228,13 @@ fn main() {
 
                 // Request steam API stuff on new players and clear
                 for player in &new_players {
+                    let verdict = server.read().unwrap()
+                        .get_player_record(*player)
+                        .map(|r| {
+                            r.verdict
+                        }).unwrap_or(Verdict::Player);
                     steam_api_send
-                        .send(steamapi::SteamAPIMessage::Lookup(*player))
+                        .send(steamapi::SteamAPIMessage::Lookup(*player, verdict))
                         .unwrap();
                 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -225,7 +225,6 @@ fn main() {
                             },
                             SteamAPIResponse::FriendLists(friendlist_results) => {
                                 for result in friendlist_results {
-                                    println!("Response: {:?}", result.0);
                                     match result.1 {
                                         // Player has public friend list
                                         Ok(friend_list) => {
@@ -314,9 +313,6 @@ fn main() {
                             }      
                         }).collect();
                     }
-                    for user in &queued_friendlist_req {
-                        println!("Requesting: {:?}", user);
-                    }  
                     
                     steam_api_send
                         .send(steamapi::SteamAPIMessage::CheckFriends(queued_friendlist_req.clone()))

--- a/src/main.rs
+++ b/src/main.rs
@@ -222,7 +222,6 @@ fn main() {
                                 server.write().unwrap().insert_steam_info(info.0, info.1);
                             },
                             SteamAPIResponse::FriendLists((steamid, result)) => {
-                                println!("Response: {:?}", u64::from(steamid));
                                 match result {
                                     // Player has public friend list
                                     Ok(friend_list) => {
@@ -318,9 +317,6 @@ fn main() {
                                 }
                             }      
                         }).collect();
-                    }
-                    if queued_friendlist_req.len() > 0 {
-                        println!("Request size: {}", queued_friendlist_req.len());
                     }
                     
                     steam_api_send

--- a/src/main.rs
+++ b/src/main.rs
@@ -221,29 +221,28 @@ fn main() {
                             SteamAPIResponse::SteamInfo(info) => {
                                 server.write().unwrap().insert_steam_info(info.0, info.1);
                             },
-                            SteamAPIResponse::FriendLists(friendlist_results) => {
-                                for (steamid, result) in friendlist_results {
-                                    println!("Response: {:?}", u64::from(steamid));
-                                    match result {
-                                        // Player has public friend list
-                                        Ok(friend_list) => {
-                                            server.write().unwrap().update_friends_list(steamid, friend_list);
-                                        },
-                                        // Player has private friend list
-                                        Err(_) => {
-                                            server.write().unwrap().private_friends_list(&steamid);
-                                            match server.read().unwrap().get_player_record(steamid) {
-                                                Some(record) => {
-                                                    if  record.verdict == Verdict::Cheater ||
-                                                        record.verdict == Verdict::Bot {
-                                                        need_all_friends_lists = true;
-                                                    }
-                                                },
-                                                _ => {}
-                                            }; 
-                                        }
-                                    };
-                                }
+                            SteamAPIResponse::FriendLists((steamid, result)) => {
+                                println!("Response: {:?}", u64::from(steamid));
+                                match result {
+                                    // Player has public friend list
+                                    Ok(friend_list) => {
+                                        server.write().unwrap().update_friends_list(steamid, friend_list);
+                                    },
+                                    // Player has private friend list
+                                    Err(_) => {
+                                        server.write().unwrap().private_friends_list(&steamid);
+                                        match server.read().unwrap().get_player_record(steamid) {
+                                            Some(record) => {
+                                                if  record.verdict == Verdict::Cheater ||
+                                                    record.verdict == Verdict::Bot {
+                                                    need_all_friends_lists = true;
+                                                }
+                                            },
+                                            _ => {}
+                                        }; 
+                                    }
+                                };
+                            
                             }
                         }
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -268,7 +268,7 @@ fn main() {
                             r.verdict
                         }).unwrap_or(Verdict::Player);
                     steam_api_send
-                        .send(steamapi::SteamAPIMessage::Lookup(*player, verdict))
+                        .send(steamapi::SteamAPIMessage::Lookup(*player))
                         .unwrap();
                     
                     match settings.read().unwrap().get_friends_api_usage() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -150,6 +150,7 @@ fn main() {
 
             // Steam API
             let mut server = Server::new(playerlist);
+            server.set_steam_user(&settings.get_steam_user());
             let (steam_api_send, steam_api_recv) = unbounded_channel();
             let (mut steam_api_recv, mut steam_api) =
                 SteamAPIManager::new(settings.get_steam_api_key(), steam_api_recv);

--- a/src/main.rs
+++ b/src/main.rs
@@ -225,6 +225,7 @@ fn main() {
                             },
                             SteamAPIResponse::FriendLists(friendlist_results) => {
                                 for result in friendlist_results {
+                                    println!("Response: {:?}", result.0);
                                     match result.1 {
                                         // Player has public friend list
                                         Ok(friend_list) => {
@@ -305,7 +306,7 @@ fn main() {
                                     if record.1.verdict == Verdict::Cheater || record.1.verdict == Verdict::Bot {
                                         need_all_friends_lists = true;
                                     }
-                                    return Some(*record.0);
+                                    return None;
                                 }
                                 None => {
                                     return Some(*record.0);
@@ -313,7 +314,10 @@ fn main() {
                             }      
                         }).collect();
                     }
-
+                    for user in &queued_friendlist_req {
+                        println!("Requesting: {:?}", user);
+                    }  
+                    
                     steam_api_send
                         .send(steamapi::SteamAPIMessage::CheckFriends(queued_friendlist_req.clone()))
                         .unwrap();

--- a/src/player.rs
+++ b/src/player.rs
@@ -145,7 +145,6 @@ pub struct SteamInfo {
     pub profile_visibility: ProfileVisibility,
     pub time_created: Option<i64>,
     pub country_code: Option<Arc<str>>,
-
     pub vac_bans: i64,
     pub game_bans: i64,
     pub days_since_last_ban: Option<i64>,

--- a/src/server.rs
+++ b/src/server.rs
@@ -37,7 +37,8 @@ pub struct Server {
     #[serde(skip)]
     player_records: PlayerRecords,
     #[serde(skip)]
-    friends_list: Vec<Friend>,
+    friends_lists: HashMap<SteamID, Vec<Friend>>,
+    friends_is_public: HashMap<SteamID, bool>, // True if public, False if private, no entry if we haven't checked yet.
 }
 
 #[derive(Debug, Serialize)]
@@ -60,7 +61,8 @@ impl Server {
             player_history: VecDeque::with_capacity(MAX_HISTORY_LEN),
             gamemode: None,
             player_records: playerlist,
-            friends_list: Vec::new(),
+            friends_lists: HashMap::new(),
+            friends_is_public: HashMap::new()
         }
     }
 
@@ -152,8 +154,132 @@ impl Server {
         found
     }
 
-    pub fn update_friends_list(&mut self, friendslist: Vec<Friend>) {
-        self.friends_list = friendslist;
+    // Updates friends lists of a user
+    // Propagates to all other friends lists to ensure two-way lookup possible.
+    // Only call if friends list was obtained directly from Steam API (i.e. friends list is public)
+    pub fn update_friends_list(&mut self, id: SteamID, friendslist: Vec<Friend>) {
+        self.friends_is_public.insert(id, true);
+
+        let oldfriends = self.friends_lists.insert(id, friendslist);
+
+        // Propagate to all other hashmap entries
+        for friend in friendslist {
+            match self.friends_lists.get_mut(&friend.steamid) {
+                // Friend's friendlist in memory
+                Some(friends_of_friend) => {
+                    match friends_of_friend.iter().find(|f| f.steamid == id) {
+                        Some(id_friend) => {
+                            // player already in friend's friends list, update friend_since in case it changed.
+                            id_friend.friend_since = friend.friend_since;
+                        },
+                        None => {
+                            friends_of_friend.push(Friend { steamid: id, friend_since: friend.friend_since });
+                        }
+                    }
+                }
+                // Friend's friendlist isn't in memory yet; create a new vector with player.
+                None => {
+                    let mut friends_of_friend = Vec::new();
+                    friends_of_friend.push(Friend { steamid: id, friend_since: friend.friend_since });
+                    self.friends_lists.insert(friend.steamid, friends_of_friend);
+                }
+            }
+        }
+
+        // If a player's friend has been unfriended, remove player from friend's hashmap
+        match oldfriends {
+            Some(oldfriends) => {
+                let oldfriends_ids = oldfriends.iter().map(|f| {
+                    f.steamid
+                }).filter(|fid| {
+                    friendslist.iter().find(|f| f.steamid == *fid).is_none()
+                });
+                for oldfriend_id in oldfriends_ids {
+                    self.remove_from_friends_list(&oldfriend_id, &id)
+                }
+            },
+            None => {}
+        }
+    }
+
+    // Mark a friends list as being private, trim all now-stale information.
+    pub fn private_friends_list (&self, steamid: &SteamID) {
+        let old_vis_state = self.friends_is_public.insert(*steamid, false);
+        let old_friendslist = self.friends_lists.get_mut(steamid);
+        
+        match (old_vis_state, old_friendslist) {
+            (Some(old_vis_state), Some(old_friendslist)) => {
+                // Already processed, this function is the only one that sets friends lists to private.
+                if old_vis_state == false { return; } 
+
+                for friend in old_friendslist {
+                    let friends_of_friend = self.friends_lists.get(&friend.steamid);
+                    match (self.friends_is_public.get(&friend.steamid), friends_of_friend){
+                        // If friend doesn't have any friends on record, nothing to remove.
+                        (_, None) => {
+                            continue;
+                        }
+                        (is_public, Some(friends_of_friend)) => {
+                            // If friend's friendlist is public, that information isn't stale.
+                            if is_public.is_some_and(|p| *p) { continue; }
+                            self.remove_from_friends_list(&friend.steamid, &steamid);
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    // Helper function to remove a friend from a player's friendlist.
+    fn remove_from_friends_list(&self, player: &SteamID, friend_to_remove: &SteamID) {
+        match self.friends_lists.get_mut(&friend_to_remove) {
+            Some(friends) => {
+                match friends.iter().position(|f| f.steamid == *friend_to_remove) {
+                    Some(i) => {
+                        friends.remove(i);
+                    },
+                    None => {}
+                }
+            }
+            None => {}
+        }
+    }
+
+    // Return all known friends of a user, as well as their friend's list visibility as a bool.
+    pub fn get_friends_list(&self, steamid: &SteamID) -> (Option<&Vec<Friend>>, Option<&bool>) {
+        let friends = self.friends_lists.get(steamid);
+        let is_public = self.friends_is_public.get(steamid);
+
+        return (friends, is_public);
+    }
+
+    pub fn is_friends(&self, friend1: &SteamID, friend2: &SteamID) -> Option<bool> {
+        let ispublic_1 = self.friends_is_public.get(friend1);
+        let ispublic_2 = self.friends_is_public.get(friend2);
+
+        // If both friends lists are private, we can't say for sure.
+        if !ispublic_1.is_some_and(|p| *p) && !ispublic_2.is_some_and(|p| *p) {
+            return None;
+        }
+        
+        let friends_list_1 = self.friends_lists.get(friend1);
+        let friends_list_2 = self.friends_lists.get(friend2);
+
+        match (friends_list_1, friends_list_2) {
+            (Some(friends_list_1), _) => {
+                return Some(friends_list_1.iter().any(|f| {
+                    f.steamid == *friend2
+                }));
+            }
+            (_, Some(friends_list_2)) => {
+                return Some(friends_list_2.iter().any(|f| {
+                    f.steamid == *friend1
+                }));
+            }
+            _ => {}
+        }
+        return Some(false);
     }
 
     /// Retrieve the player history somewhere in the range 0..100
@@ -187,12 +313,6 @@ impl Server {
     pub fn get_player_record_mut(&mut self, steamid: SteamID) -> Option<PlayerRecordLock> {
         self.player_records
             .get_record_mut(steamid, &mut self.players, &mut self.player_history)
-    }
-
-    pub fn get_friend(&self, steamid: &SteamID) -> Option<&Friend> {
-        self.friends_list
-            .iter()
-            .find(|&friend| &friend.steamid == steamid)
     }
 
     pub fn get_players(&self) -> &HashMap<SteamID, Player> {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -38,7 +38,6 @@ pub enum FriendsAPIUsage {
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(default)]
-
 pub struct Settings {
     #[serde(skip)]
     config_path: Option<PathBuf>,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -29,9 +29,18 @@ pub enum ConfigFilesError {
     #[error("{0:?}")]
     Other(#[from] anyhow::Error),
 }
+#[derive(Debug, Serialize,Deserialize, PartialEq)]
+pub enum FriendsAPIUsage {
+    None,
+    CheatersOnly,
+    All
+}
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(default)]
+
+// TODO: Add setting for requesting friends for none/cheaters/all
+
 pub struct Settings {
     #[serde(skip)]
     config_path: Option<PathBuf>,
@@ -39,6 +48,7 @@ pub struct Settings {
     steam_user: Option<SteamID>,
     #[serde(skip)]
     tf2_directory: PathBuf,
+    friends_api_usage: FriendsAPIUsage,
     rcon_password: Arc<str>,
     steam_api_key: Arc<str>,
     port: u16,
@@ -309,6 +319,14 @@ impl Settings {
         self.config_path = Some(config);
     }
 
+    pub fn set_friends_api_usage(&mut self, friends_api_usage: FriendsAPIUsage) {
+        self.friends_api_usage = friends_api_usage;
+    }
+
+    pub fn get_friends_api_usage(&self) -> &FriendsAPIUsage {
+        &self.friends_api_usage
+    }
+
     /// Attempts to find (and create) a directory to be used for configuration files
     pub fn locate_config_directory() -> Result<PathBuf, ConfigFilesError> {
         let dirs = ProjectDirs::from("com.megascatterbomb", "MAC", "MACClient")
@@ -345,6 +363,7 @@ impl Default for Settings {
             tf2_directory: PathBuf::default(),
             rcon_password: "mac_rcon".into(),
             steam_api_key: "YOUR_API_KEY_HERE".into(),
+            friends_api_usage: FriendsAPIUsage::CheatersOnly,
             port: 3621,
             autolaunch_ui: false,
             override_tf2_dir: None,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -39,8 +39,6 @@ pub enum FriendsAPIUsage {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(default)]
 
-// TODO: Add setting for requesting friends for none/cheaters/all
-
 pub struct Settings {
     #[serde(skip)]
     config_path: Option<PathBuf>,
@@ -363,7 +361,7 @@ impl Default for Settings {
             tf2_directory: PathBuf::default(),
             rcon_password: "mac_rcon".into(),
             steam_api_key: "YOUR_API_KEY_HERE".into(),
-            friends_api_usage: FriendsAPIUsage::CheatersOnly,
+            friends_api_usage: FriendsAPIUsage::None, // TODO: Change to CheatersOnly once frontend impl complete.
             port: 3621,
             autolaunch_ui: false,
             override_tf2_dir: None,


### PR DESCRIPTION
Adds functionality to pull friends lists of users within the game from the Steam API.

Adds a setting that determines when to pull friends lists from Steam. This setting is useful as the endpoint for friends lists cannot be batched like player summaries. The config setting defaults to `None` for the time being; this may be changed in the future once features exist that require it.

- None: No friend information is pulled.
- CheatersOnly: self-explanatory, however if a cheater's friends list is private, then every player on the server will be checked anyway as this can reveal more information.
- All: Always pull friend information.

My intention is to update the API spec to accommodate this information so it can be accessed by the frontend, however the existing implementation is sufficient for others to debug and build upon if they wish.