### PR TITLE
Use a single player cache instead of separate lists for connected and historical players

### DIFF
--- a/src/io/g15.rs
+++ b/src/io/g15.rs
@@ -248,7 +248,7 @@ impl G15Parser {
                 if let Some(pat_caps) = pat_caps {
                     // Call the corresponding function to store the capture groups, as we have found a match
                     match pat.1(pat_caps, &mut players) {
-                        Err(why) => println!("Parse error - {} at line {}", why, line),
+                        Err(why) => tracing::error!("Parse error - {} at line {}", why, line),
                         Ok(value) => (),
                     }
                 }

--- a/src/io/regexes.rs
+++ b/src/io/regexes.rs
@@ -124,7 +124,7 @@ impl ChatMessage {
 // Includes players on server, player name, state, steamid, time connected
 // If no player exists on the server with a steamid from here, it creates a new player and adds it to the list
 pub const REGEX_STATUS: &str =
-    r#"^#\s*(\d+)\s"(.*)"\s+(\[U:\d:\d+\])\s+(\d*:?\d\d:\d\d)\s+(\d+)\s*(\d+)\s*(\w+).*$"#;
+    r#"^#\s*(\d+)\s"(.*)"\s+(\[U:\d:\d+\])\s+((?:[\ds]+:?)+)\s+(\d+)\s*(\d+)\s*(\w+).*$"#;
 
 #[derive(Debug, Clone)]
 pub struct StatusLine {

--- a/src/main.rs
+++ b/src/main.rs
@@ -150,7 +150,7 @@ fn main() {
 
             // Steam API
             let mut server = Server::new(playerlist);
-            server.set_steam_user(&settings.get_steam_user());
+            server.set_user(settings.get_steam_user());
             let (steam_api_send, steam_api_recv) = unbounded_channel();
             let (mut steam_api_recv, mut steam_api) =
                 SteamAPIManager::new(settings.get_steam_api_key(), steam_api_recv);
@@ -191,9 +191,8 @@ fn main() {
                     // IO output
                     io_output_iter = io_recv.recv() => {
                         for output in io_output_iter.unwrap() {
-                            let user = settings.read().unwrap().get_steam_user();
                             for new_player in server.write().unwrap()
-                                .handle_io_output(output, user)
+                                .handle_io_output(output)
                                 .into_iter()
                             {
                                 new_players.push(new_player);
@@ -285,32 +284,32 @@ fn main() {
                     if need_all_friends_lists {
                         need_all_friends_lists = false;
                         let server_read: std::sync::RwLockReadGuard<'_, Server> = server.read().unwrap();
-                        queued_friendlist_req = server_read.get_players()
-                        .iter()
-                        .filter_map(|(steamid, _)| {
-                            if inprogress_friendlist_req.contains(steamid) {
-                                return None;
-                            }
-                            // If friends list visibility is Some, we've looked up that user before.
-                            match server_read.get_friends_list(steamid).1 {
-                                Some(true) => {
+                        queued_friendlist_req = server_read.players().connected()
+                            .map(|p| &p.steamid)
+                            .filter_map(|steamid| {
+                                if inprogress_friendlist_req.contains(steamid) {
                                     return None;
                                 }
-                                Some(false) => {
-                                    let record = server_read.get_player_record(*steamid);
-                                    if record.is_some_and(|r | {
-                                        r.verdict == Verdict::Cheater ||
-                                        r.verdict == Verdict::Bot
-                                     }) {
-                                        need_all_friends_lists = true;
+                                // If friends list visibility is Some, we've looked up that user before.
+                                match server_read.get_friends_list(steamid).1 {
+                                    Some(true) => {
+                                        return None;
                                     }
-                                    return None;
-                                }
-                                None => {
-                                    return Some(*steamid);
-                                }
-                            }      
-                        }).collect();
+                                    Some(false) => {
+                                        let record = server_read.get_player_record(*steamid);
+                                        if record.is_some_and(|r | {
+                                            r.verdict == Verdict::Cheater ||
+                                            r.verdict == Verdict::Bot
+                                         }) {
+                                            need_all_friends_lists = true;
+                                        }
+                                        return None;
+                                    }
+                                    None => {
+                                        return Some(*steamid);
+                                    }
+                                }      
+                            }).collect();
                     }
                     
                     steam_api_send

--- a/src/main.rs
+++ b/src/main.rs
@@ -215,7 +215,7 @@ fn main() {
                                     // Player has private friend list
                                     Err(_) => {
                                         server.write().unwrap().private_friends_list(&steamid);
-                                        match server.read().unwrap().get_player_record(steamid) {
+                                        match server.read().unwrap().players().record(&steamid) {
                                             Some(record) => {
                                                 if  record.verdict == Verdict::Cheater ||
                                                     record.verdict == Verdict::Bot {
@@ -250,7 +250,8 @@ fn main() {
                 // Request steam API stuff on new players
                 for player in &new_players {
                     let verdict = server.read().unwrap()
-                        .get_player_record(*player)
+                        .players()
+                        .record(player)
                         .map(|r| {
                             r.verdict
                         }).unwrap_or(Verdict::Player);
@@ -296,7 +297,7 @@ fn main() {
                                         return None;
                                     }
                                     Some(false) => {
-                                        let record = server_read.get_player_record(*steamid);
+                                        let record = server_read.players().record(steamid);
                                         if record.is_some_and(|r | {
                                             r.verdict == Verdict::Cheater ||
                                             r.verdict == Verdict::Bot

--- a/src/player.rs
+++ b/src/player.rs
@@ -18,7 +18,7 @@ pub struct Player {
     #[serde(rename = "isSelf")]
     pub is_self: bool,
     #[serde(rename = "gameInfo")]
-    pub game_info: GameInfo,
+    pub game_info: Option<GameInfo>,
     #[serde(rename = "steamInfo")]
     pub steam_info: Option<SteamInfo>,
     #[serde(rename = "customData")]
@@ -41,7 +41,7 @@ impl Player {
             name: status.name.clone(),
             steamid: status.steamid,
             is_self,
-            game_info: GameInfo::new_from_status(status),
+            game_info: Some(GameInfo::new_from_status(status)),
             steam_info: None,
             custom_data: serde_json::Value::Object(Map::new()),
             tags: Vec::new(),
@@ -55,7 +55,7 @@ impl Player {
 
     pub(crate) fn new_from_g15(g15: &G15Player, user: Option<SteamID>) -> Option<Player> {
         let steamid = g15.steamid?;
-        let game_info = GameInfo::new_from_g15(g15)?;
+        let game_info = GameInfo::new_from_g15(g15);
         let is_self = user.map(|user| user == steamid).unwrap_or(false);
 
         Some(Player {

--- a/src/player.rs
+++ b/src/player.rs
@@ -1,131 +1,301 @@
 use serde::{Serialize, Serializer};
-use serde_json::Map;
-use std::sync::Arc;
+use std::{
+    collections::{HashMap, HashSet, VecDeque},
+    ops::{Deref, DerefMut},
+    sync::Arc,
+};
 use steamid_ng::SteamID;
 
 use crate::{
     io::{g15::G15Player, regexes::StatusLine},
-    player_records::{PlayerRecord, Verdict},
+    player_records::{default_custom_data, PlayerRecords, Verdict},
 };
 
-// Player
-
-#[derive(Debug, Clone, Serialize)]
-pub struct Player {
-    pub name: Arc<str>,
-    #[serde(rename = "steamID64", serialize_with = "serialize_steamid_as_string")]
-    pub steamid: SteamID,
-    #[serde(rename = "isSelf")]
-    pub is_self: bool,
-    #[serde(rename = "gameInfo")]
-    pub game_info: Option<GameInfo>,
-    #[serde(rename = "steamInfo")]
-    pub steam_info: Option<SteamInfo>,
-    #[serde(rename = "customData")]
-    pub custom_data: serde_json::Value,
-    pub tags: Vec<Arc<str>>,
-    #[serde(rename = "localVerdict")]
-    pub local_verdict: Verdict,
-    pub convicted: bool,
-    #[serde(rename = "previousNames")]
-    pub previous_names: Vec<Arc<str>>,
-    pub friends: Vec<Friend>,
-    #[serde(rename = "friendsIsPublic")]
-    pub friends_is_public: Option<bool>,
+pub mod tags {
+    pub const FRIEND: &str = "Friend";
 }
 
-impl Player {
-    pub(crate) fn new_from_status(status: &StatusLine, user: Option<SteamID>) -> Player {
-        let is_self = user.map(|user| user == status.steamid).unwrap_or(false);
-        Player {
-            name: status.name.clone(),
-            steamid: status.steamid,
-            is_self,
-            game_info: Some(GameInfo::new_from_status(status)),
-            steam_info: None,
-            custom_data: serde_json::Value::Object(Map::new()),
-            tags: Vec::new(),
-            local_verdict: Verdict::Player,
-            convicted: false,
-            previous_names: Vec::new(),
-            friends: Vec::new(),
-            friends_is_public: None,
+const MAX_HISTORY_LEN: usize = 100;
+
+pub struct Players {
+    pub game_info: HashMap<SteamID, GameInfo>,
+    pub steam_info: HashMap<SteamID, SteamInfo>,
+    pub friend_info: HashMap<SteamID, FriendInfo>,
+    pub records: PlayerRecords,
+    pub tags: HashMap<SteamID, HashSet<Arc<str>>>,
+
+    pub connected: Vec<SteamID>,
+    pub history: VecDeque<SteamID>,
+
+    pub user: Option<SteamID>,
+}
+
+#[allow(dead_code)]
+impl Players {
+    pub(crate) fn new(records: PlayerRecords) -> Players {
+        Players {
+            game_info: HashMap::new(),
+            steam_info: HashMap::new(),
+            friend_info: HashMap::new(),
+            tags: HashMap::new(),
+            records,
+
+            connected: Vec::new(),
+            history: VecDeque::with_capacity(MAX_HISTORY_LEN),
+            user: None,
         }
     }
 
-    pub(crate) fn new_from_g15(g15: &G15Player, user: Option<SteamID>) -> Option<Player> {
-        let steamid = g15.steamid?;
-        let game_info = GameInfo::new_from_g15(g15);
-        let is_self = user.map(|user| user == steamid).unwrap_or(false);
-
-        Some(Player {
-            name: g15.name.clone()?,
-            steamid,
-            is_self,
-            game_info,
-            steam_info: None,
-            custom_data: serde_json::Value::Object(Map::new()),
-            tags: Vec::new(),
-            local_verdict: Verdict::Player,
-            convicted: false,
-            previous_names: Vec::new(),
-            friends: Vec::new(),
-            friends_is_public: None,
-        })
+    /// Check if a player has a particular tag set
+    pub fn has_tag(&self, steamid: SteamID, tag: &str) -> bool {
+        self.tags
+            .get(&steamid)
+            .map(|t| t.contains(tag))
+            .unwrap_or(false)
     }
 
-    /// Given a record, update this player with the included data.
-    pub fn update_from_record(&mut self, record: PlayerRecord) {
-        if record.steamid != self.steamid {
-            tracing::error!("Updating player with wrong record.");
-            return;
-        }
-
-        self.custom_data = record.custom_data;
-        self.local_verdict = record.verdict;
-        self.previous_names = record.previous_names;
+    /// Set a particular tag on a player
+    pub fn set_tag(&mut self, steamid: SteamID, tag: Arc<str>) {
+        self.tags.entry(steamid).or_default().insert(tag);
     }
 
-    pub fn update_friends(&mut self, friends: Vec<Friend>, is_public: Option<bool>, userid: Option<SteamID>) {
-        self.friends = friends;
-        self.friends_is_public = is_public;
-        if userid.is_some() {
-            let userid = userid.unwrap();
-            let is_friends_with_user = self.friends.iter().any(|f| f.steamid == userid);
-            let has_friend_tag = self.tags.iter().any(|t| &*t.as_ref() == "Friend");
-            
-            if is_friends_with_user && !has_friend_tag {
-                self.tags.push(Arc::from("Friend"));
-            } else if !is_friends_with_user && has_friend_tag {
-                let i = self.tags.iter().position(|t| &*t.as_ref() == "Friend");
-                if i.is_some() {
-                    self.tags.remove(i.unwrap());
-                }
+    /// Clear a particular tag on a player
+    pub fn clear_tag(&mut self, steamid: SteamID, tag: &str) {
+        if let Some(tags) = self.tags.get_mut(&steamid) {
+            tags.remove(tag);
+            if tags.len() == 0 {
+                self.tags.remove(&steamid);
             }
         }
     }
 
-    /// Create a record from the current player
-    #[allow(dead_code)]
-    pub fn get_record(&self) -> PlayerRecord {
-        PlayerRecord {
-            steamid: self.steamid,
-            custom_data: self.custom_data.clone(),
-            verdict: self.local_verdict,
-            previous_names: self.previous_names.clone(),
+    /// Updates friends lists of a user
+    /// Propagates to all other friends lists to ensure two-way lookup possible.
+    /// Only call if friends list was obtained directly from Steam API (i.e. friends list is public)
+    pub fn update_friends_list(&mut self, steamid: SteamID, friendslist: Vec<Friend>) {
+        // Propagate to all other hashmap entries
+
+        for friend in friendslist.iter() {
+            if let Some(other_friend) = self.friend_info.get_mut(&friend.steamid) {
+                other_friend.push(Friend {
+                    steamid,
+                    friend_since: friend.friend_since,
+                });
+            }
         }
+
+        let oldfriends = self.set_friends(steamid, friendslist);
+
+        // If a player's friend has been unfriended, remove player from friend's hashmap
+        for oldfriend in oldfriends {
+            self.remove_from_friends_list(&oldfriend, &steamid);
+        }
+    }
+
+    /// Sets the friends list and friends list visibility, returning any old friends that have been removed
+    fn set_friends(&mut self, steamid: SteamID, friends: Vec<Friend>) -> Vec<SteamID> {
+        let friend_info = self.friend_info.entry(steamid).or_default();
+
+        friend_info.public = Some(true);
+
+        let mut removed_friends = friends;
+        friend_info.retain(|f1| !removed_friends.iter().any(|f2| f1.steamid == f2.steamid));
+        std::mem::swap(&mut removed_friends, &mut friend_info.friends);
+
+        // Update friend tag
+        if let Some(user) = self.user {
+            let is_friends_with_user = friend_info.iter().any(|f| f.steamid == user);
+
+            if is_friends_with_user {
+                self.set_tag(steamid, tags::FRIEND.into());
+            } else {
+                self.clear_tag(steamid, tags::FRIEND);
+            }
+        }
+
+        removed_friends.into_iter().map(|f| f.steamid).collect()
+    }
+
+    /// Helper function to remove a friend from a player's friendlist.
+    fn remove_from_friends_list(&mut self, steamid: &SteamID, friend_to_remove: &SteamID) {
+        if let Some(friends) = self.friend_info.get_mut(steamid) {
+            friends.retain(|f| f.steamid != *friend_to_remove);
+            if friends.len() == 0 && friends.public.is_none() {
+                self.friend_info.remove(steamid);
+            }
+        }
+
+        if let Some(friends) = self.friend_info.get_mut(friend_to_remove) {
+            friends.retain(|f| f.steamid != *steamid);
+            if friends.len() == 0 && friends.public.is_none() {
+                self.friend_info.remove(friend_to_remove);
+            }
+        }
+    }
+
+    /// Mark a friends list as being private, trim all now-stale information.
+    pub fn mark_friends_list_private(&mut self, steamid: &SteamID) {
+        let friends = self.friend_info.entry(*steamid).or_default();
+        let old_vis_state = friends.public;
+        if old_vis_state.is_some_and(|public| !public) {
+            return;
+        }
+
+        friends.public = Some(false);
+
+        let old_friendslist = friends.clone();
+
+        for friend in old_friendslist {
+            if let Some(friends_of_friend) = self.friend_info.get(&friend.steamid) {
+                // If friend's friendlist is public, that information isn't stale.
+                if friends_of_friend.public.is_some_and(|p| p) {
+                    continue;
+                }
+
+                self.remove_from_friends_list(&friend.steamid, &steamid);
+            }
+        }
+    }
+
+    /// Check if an account is friends with the user.
+    /// Returns None if we don't have enough information to tell.
+    pub fn is_friends_with_user(&self, friend: &SteamID) -> Option<bool> {
+        if let Some(user) = self.user {
+            self.are_friends(friend, &user)
+        } else {
+            None
+        }
+    }
+
+    /// Check if two accounts are friends with each other.
+    /// Returns None if we don't have enough information to tell.
+    pub fn are_friends(&self, friend1: &SteamID, friend2: &SteamID) -> Option<bool> {
+        if let Some(friends) = self.friend_info.get(friend1) {
+            if friends.iter().any(|f| f.steamid == *friend2) {
+                return Some(true);
+            }
+
+            // Friends list is public, so we should be able to see the other party regardless
+            if friends.public.is_some_and(|p| p) {
+                return Some(false);
+            }
+        }
+
+        // Other friends list is public, so 2-way lookup should have been possible
+        if self
+            .friend_info
+            .get(friend2)
+            .is_some_and(|f| f.public.is_some_and(|p| p))
+        {
+            return Some(false);
+        }
+
+        // Both are private :(
+        None
+    }
+
+    /// Moves any old players from the server into history. Any console commands (status, g15_dumpplayer, etc)
+    /// should be run before calling this function again to prevent removing all players from the player list.
+    pub fn refresh(&mut self) {
+        // Get old players
+        let unaccounted_players: Vec<SteamID> = self
+            .connected
+            .iter()
+            .filter(|&s| {
+                self.game_info
+                    .get(s)
+                    .map(|gi| gi.should_prune())
+                    .unwrap_or(true)
+            })
+            .cloned()
+            .collect();
+
+        self.connected.retain(|s| !unaccounted_players.contains(s));
+
+        // Remove any of them from the history as they will be added more recently
+        self.history
+            .retain(|p| !unaccounted_players.iter().any(|up| up == p));
+
+        // Shrink to not go past max number of players
+        let num_players = self.history.len() + unaccounted_players.len();
+        for _ in MAX_HISTORY_LEN..num_players {
+            self.history.pop_front();
+        }
+
+        for p in unaccounted_players {
+            self.history.push_back(p);
+        }
+
+        // Mark all remaining players as unaccounted, they will be marked as accounted again
+        // when they show up in status or another console command.
+        self.game_info.values_mut().for_each(GameInfo::next_cycle);
+    }
+
+    /// Gets a struct containing all the relevant data on a player in a serializable format
+    pub fn get_serializable_player(&self, steamid: &SteamID) -> Option<Player> {
+        let game_info = self.game_info.get(steamid)?;
+        let tags: Vec<&str> = self
+            .tags
+            .get(steamid)
+            .map(|tags| tags.iter().map(|t| t.as_ref()).collect())
+            .unwrap_or_default();
+
+        let record = self.records.get(steamid);
+        let previous_names = record
+            .as_ref()
+            .map(|r| r.previous_names.iter().map(|n| n.as_ref()).collect())
+            .unwrap_or_default();
+
+        let friend_info = self.friend_info.get(steamid);
+        let friends: Vec<&Friend> = friend_info
+            .as_ref()
+            .map(|fi| fi.friends.iter().collect())
+            .unwrap_or_default();
+
+        let local_verdict = record
+            .as_ref()
+            .map(|r| r.verdict)
+            .unwrap_or(Verdict::Player);
+
+        Some(Player {
+            isSelf: self.user.is_some_and(|user| user == *steamid),
+            name: game_info.name.as_ref(),
+            steamID64: *steamid,
+            localVerdict: local_verdict,
+            steamInfo: self.steam_info.get(steamid),
+            gameInfo: Some(game_info),
+            customData: record
+                .as_ref()
+                .map(|r| r.custom_data.clone())
+                .unwrap_or_else(|| default_custom_data()),
+            convicted: false,
+            tags,
+            previous_names,
+            friends,
+            friendsIsPublic: friend_info.and_then(|fi| fi.public),
+        })
     }
 }
 
-// PlayerState
+impl Serialize for Players {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let players: Vec<Player> = self
+            .connected
+            .iter()
+            .flat_map(|s| self.get_serializable_player(s))
+            .collect();
+        players.serialize(serializer)
+    }
+}
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize)]
 pub enum PlayerState {
     Active,
     Spawning,
 }
-
-// Team
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum Team {
@@ -157,8 +327,6 @@ impl Serialize for Team {
     }
 }
 
-// SteamInfo
-
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SteamInfo {
@@ -174,15 +342,6 @@ pub struct SteamInfo {
     pub vac_bans: i64,
     pub game_bans: i64,
     pub days_since_last_ban: Option<i64>,
-    // pub friends: Vec<Friend>,
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub struct Friend {
-    #[serde(rename = "steamID64", serialize_with = "serialize_steamid_as_string")]
-    pub steamid: SteamID,
-    #[serde(rename = "friendSince")]
-    pub friend_since: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -207,6 +366,7 @@ impl From<i32> for ProfileVisibility {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct GameInfo {
+    pub name: Arc<str>,
     pub userid: Arc<str>,
     pub team: Team,
     pub time: u32,
@@ -222,36 +382,77 @@ pub struct GameInfo {
     last_seen: u32,
 }
 
-impl GameInfo {
-    pub(crate) fn new_from_g15(g15: &G15Player) -> Option<GameInfo> {
-        Some(GameInfo {
-            userid: g15.userid.clone()?,
-            team: g15.team.unwrap_or(Team::Unassigned),
-            time: 0,
-            ping: g15.ping.unwrap_or(0),
-            loss: 0,
-            state: PlayerState::Active,
-            kills: g15.score.unwrap_or(0),
-            deaths: g15.deaths.unwrap_or(0),
-            disconnected: false,
-            last_seen: 0,
-        })
-    }
-
-    pub(crate) fn new_from_status(status: &StatusLine) -> GameInfo {
+impl Default for GameInfo {
+    fn default() -> Self {
         GameInfo {
-            userid: status.userid.clone(),
+            name: "".into(),
+            userid: "".into(),
             team: Team::Unassigned,
-            time: status.time,
-            ping: status.ping,
-            loss: status.loss,
-            state: status.state,
+            time: 0,
+            ping: 0,
+            loss: 0,
+            state: PlayerState::Spawning,
             kills: 0,
             deaths: 0,
             disconnected: false,
-
             last_seen: 0,
         }
+    }
+}
+
+impl GameInfo {
+    pub(crate) fn new() -> GameInfo {
+        Default::default()
+    }
+
+    pub(crate) fn new_from_g15(g15: G15Player) -> Option<GameInfo> {
+        if g15.userid.is_none() {
+            return None;
+        }
+
+        let mut game_info = GameInfo::new();
+        game_info.update_from_g15(g15);
+        Some(game_info)
+    }
+
+    pub(crate) fn new_from_status(status: StatusLine) -> GameInfo {
+        let mut game_info = GameInfo::new();
+        game_info.update_from_status(status);
+        game_info
+    }
+
+    pub(crate) fn update_from_g15(&mut self, g15: G15Player) {
+        if let Some(name) = g15.name {
+            self.name = name;
+        }
+        if let Some(userid) = g15.userid {
+            self.userid = userid;
+        }
+        if let Some(team) = g15.team {
+            self.team = team;
+        }
+        if let Some(ping) = g15.ping {
+            self.ping = ping;
+        }
+        if let Some(kills) = g15.score {
+            self.kills = kills;
+        }
+        if let Some(deaths) = g15.deaths {
+            self.deaths = deaths;
+        }
+
+        self.acknowledge();
+    }
+
+    pub(crate) fn update_from_status(&mut self, status: StatusLine) {
+        self.name = status.name;
+        self.userid = status.userid;
+        self.time = status.time;
+        self.ping = status.ping;
+        self.loss = status.loss;
+        self.state = status.state;
+
+        self.acknowledge();
     }
 
     pub(crate) fn next_cycle(&mut self) {
@@ -263,14 +464,51 @@ impl GameInfo {
         }
     }
 
-    pub(crate) fn acknowledge(&mut self) {
-        self.last_seen = 0;
-        self.disconnected = false;
-    }
-
     pub(crate) fn should_prune(&self) -> bool {
         const CYCLE_LIMIT: u32 = 5;
         self.last_seen > CYCLE_LIMIT
+    }
+
+    fn acknowledge(&mut self) {
+        self.last_seen = 0;
+        self.disconnected = false;
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct Friend {
+    #[serde(rename = "steamID64", serialize_with = "serialize_steamid_as_string")]
+    pub steamid: SteamID,
+    #[serde(rename = "friendSince")]
+    pub friend_since: u64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct FriendInfo {
+    pub public: Option<bool>,
+    friends: Vec<Friend>,
+}
+
+impl Default for FriendInfo {
+    fn default() -> Self {
+        FriendInfo {
+            public: None,
+            friends: Vec::new(),
+        }
+    }
+}
+
+impl Deref for FriendInfo {
+    type Target = Vec<Friend>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.friends
+    }
+}
+
+impl DerefMut for FriendInfo {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.friends
     }
 }
 
@@ -278,4 +516,24 @@ impl GameInfo {
 
 fn serialize_steamid_as_string<S: Serializer>(steamid: &SteamID, s: S) -> Result<S::Ok, S::Error> {
     format!("{}", u64::from(*steamid)).serialize(s)
+}
+
+#[allow(non_snake_case)]
+#[derive(Debug, Serialize)]
+pub struct Player<'a> {
+    pub isSelf: bool,
+    pub name: &'a str,
+    #[serde(serialize_with = "serialize_steamid_as_string")]
+    pub steamID64: SteamID,
+
+    pub steamInfo: Option<&'a SteamInfo>,
+    pub gameInfo: Option<&'a GameInfo>,
+    pub customData: serde_json::Value,
+    pub localVerdict: Verdict,
+    pub convicted: bool,
+    pub tags: Vec<&'a str>,
+    pub previous_names: Vec<&'a str>,
+
+    pub friends: Vec<&'a Friend>,
+    pub friendsIsPublic: Option<bool>,
 }

--- a/src/player_records.rs
+++ b/src/player_records.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{HashMap, VecDeque},
+    collections::HashMap,
     fmt::Display,
     io::ErrorKind,
     ops::{Deref, DerefMut},
@@ -135,13 +135,11 @@ impl PlayerRecords {
         &'a mut self,
         steamid: SteamID,
         players: &'a mut HashMap<SteamID, Player>,
-        history: &'a mut VecDeque<Player>,
     ) -> Option<PlayerRecordLock> {
         if self.records.contains_key(&steamid) {
             Some(PlayerRecordLock {
                 steamid,
                 players,
-                history,
                 playerlist: self,
             })
         } else {
@@ -237,7 +235,6 @@ impl Display for Verdict {
 pub struct PlayerRecordLock<'a> {
     playerlist: &'a mut PlayerRecords,
     players: &'a mut HashMap<SteamID, Player>,
-    history: &'a mut VecDeque<Player>,
     steamid: SteamID,
 }
 
@@ -272,10 +269,6 @@ impl Drop for PlayerRecordLock<'_> {
 
         // Update server players and history
         if let Some(p) = self.players.get_mut(&self.steamid) {
-            p.update_from_record(record.clone());
-        }
-
-        if let Some(p) = self.history.iter_mut().find(|p| p.steamid == self.steamid) {
             p.update_from_record(record.clone());
         }
 

--- a/src/player_records.rs
+++ b/src/player_records.rs
@@ -127,18 +127,18 @@ impl PlayerRecords {
     }
 
     #[allow(dead_code)]
-    pub fn get_record(&self, steamid: SteamID) -> Option<&PlayerRecord> {
-        self.records.get(&steamid)
+    pub fn get_record(&self, steamid: &SteamID) -> Option<&PlayerRecord> {
+        self.records.get(steamid)
     }
 
     pub fn get_record_mut<'a>(
         &'a mut self,
-        steamid: SteamID,
+        steamid: &SteamID,
         players: &'a mut HashMap<SteamID, Player>,
     ) -> Option<PlayerRecordLock> {
         if self.records.contains_key(&steamid) {
             Some(PlayerRecordLock {
-                steamid,
+                steamid: *steamid,
                 players,
                 playerlist: self,
             })

--- a/src/player_records.rs
+++ b/src/player_records.rs
@@ -14,7 +14,6 @@ use steamid_ng::SteamID;
 
 use crate::{
     args::Args,
-    player::Player,
     settings::{ConfigFilesError, Settings},
 };
 
@@ -24,7 +23,7 @@ use crate::{
 pub struct PlayerRecords {
     #[serde(skip)]
     path: PathBuf,
-    records: HashMap<SteamID, PlayerRecord>,
+    pub records: HashMap<SteamID, PlayerRecord>,
 }
 
 impl PlayerRecords {
@@ -82,9 +81,7 @@ impl PlayerRecords {
         // Map all of the steamids to the records. They were not included when
         // serializing/deserializing the records to prevent duplication in the
         // resulting file.
-        for (steamid, record) in &mut playerlist.records {
-            record.steamid = *steamid;
-
+        for record in &mut playerlist.records.values_mut() {
             // Some old versions had the custom_data set to `null` by default, but an empty object is preferable
             // so I'm using this to fix it lol. It's really not necessary but at the time the UI wasn't
             // a fan of nulls in the custom_data and this fixes it so whatever. :3
@@ -118,37 +115,16 @@ impl PlayerRecords {
         self.path = path;
     }
 
-    pub fn insert_record(&mut self, record: PlayerRecord) {
-        self.records.insert(record.steamid, record);
-    }
-
-    pub fn get_records(&self) -> &HashMap<SteamID, PlayerRecord> {
-        &self.records
-    }
-
-    #[allow(dead_code)]
-    pub fn get_record(&self, steamid: &SteamID) -> Option<&PlayerRecord> {
-        self.records.get(steamid)
-    }
-
-    pub fn get_record_mut<'a>(
-        &'a mut self,
-        steamid: &SteamID,
-        players: &'a mut HashMap<SteamID, Player>,
-    ) -> Option<PlayerRecordLock> {
-        if self.records.contains_key(&steamid) {
-            Some(PlayerRecordLock {
-                steamid: *steamid,
-                players,
-                playerlist: self,
-            })
-        } else {
-            None
-        }
-    }
-
     pub fn locate_playerlist_file() -> Result<PathBuf, ConfigFilesError> {
         Settings::locate_config_directory().map(|dir| dir.join("playerlist.json"))
+    }
+
+    pub fn update_name(&mut self, steamid: &SteamID, name: Arc<str>) {
+        if let Some(record) = self.records.get_mut(steamid) {
+            if !record.previous_names.contains(&name) {
+                record.previous_names.push(name);
+            }
+        }
     }
 }
 
@@ -165,13 +141,25 @@ impl Default for PlayerRecords {
     }
 }
 
+impl Deref for PlayerRecords {
+    type Target = HashMap<SteamID, PlayerRecord>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.records
+    }
+}
+
+impl DerefMut for PlayerRecords {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.records
+    }
+}
+
 // PlayerRecord
 
 /// A Record of a player stored in the persistent personal playerlist
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct PlayerRecord {
-    #[serde(skip)]
-    pub steamid: SteamID,
     #[serde(default = "default_custom_data")]
     pub custom_data: serde_json::Value,
     pub verdict: Verdict,
@@ -180,9 +168,8 @@ pub struct PlayerRecord {
 }
 
 impl PlayerRecord {
-    pub fn new(steamid: SteamID) -> PlayerRecord {
+    pub fn new() -> PlayerRecord {
         PlayerRecord {
-            steamid,
             custom_data: serde_json::Value::Object(serde_json::Map::new()),
             verdict: Verdict::Player,
             previous_names: Vec::new(),
@@ -212,7 +199,13 @@ impl PlayerRecord {
     }
 }
 
-fn default_custom_data() -> serde_json::Value {
+impl Default for PlayerRecord {
+    fn default() -> Self {
+        PlayerRecord::new()
+    }
+}
+
+pub fn default_custom_data() -> serde_json::Value {
     serde_json::Value::Object(Map::new())
 }
 
@@ -229,56 +222,5 @@ pub enum Verdict {
 impl Display for Verdict {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:?}", self)
-    }
-}
-
-pub struct PlayerRecordLock<'a> {
-    playerlist: &'a mut PlayerRecords,
-    players: &'a mut HashMap<SteamID, Player>,
-    steamid: SteamID,
-}
-
-impl Deref for PlayerRecordLock<'_> {
-    type Target = PlayerRecord;
-
-    fn deref(&self) -> &Self::Target {
-        self.playerlist
-            .records
-            .get(&self.steamid)
-            .expect("Mutating player record.")
-    }
-}
-
-impl DerefMut for PlayerRecordLock<'_> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.playerlist
-            .records
-            .get_mut(&self.steamid)
-            .expect("Reading player record.")
-    }
-}
-
-// Update all players the server has with the updated record
-impl Drop for PlayerRecordLock<'_> {
-    fn drop(&mut self) {
-        let record = self
-            .playerlist
-            .records
-            .get(&self.steamid)
-            .expect("Reading player record");
-
-        // Update server players and history
-        if let Some(p) = self.players.get_mut(&self.steamid) {
-            p.update_from_record(record.clone());
-        }
-
-        // Update playerlist
-        if record.is_empty() {
-            self.playerlist.records.remove(&self.steamid);
-        }
-
-        if let Err(e) = self.playerlist.save() {
-            tracing::error!("Failed to save playerlist: {:?}", e);
-        }
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,8 +1,5 @@
-use serde::{Serialize, Serializer};
-use std::{
-    collections::{HashMap, VecDeque},
-    sync::Arc,
-};
+use serde::Serialize;
+use std::sync::Arc;
 use steamid_ng::SteamID;
 
 use crate::{
@@ -11,107 +8,22 @@ use crate::{
         regexes::{self, ChatMessage, PlayerKill, StatusLine},
         IOOutput,
     },
-    player::{Friend, GameInfo, Player, SteamInfo},
-    player_records::{PlayerRecord, PlayerRecordLock, PlayerRecords},
+    player::{GameInfo, Players},
+    player_records::PlayerRecords,
 };
-
-const MAX_HISTORY_LEN: usize = 100;
 
 // Server
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Server {
-    user: Option<SteamID>,
     map: Option<Arc<str>>,
     ip: Option<Arc<str>>,
     hostname: Option<Arc<str>>,
     max_players: Option<u32>,
     num_players: Option<u32>,
-    players: Players,
-
     gamemode: Option<Gamemode>,
-
-    #[serde(skip)]
-    friends_lists: HashMap<SteamID, Vec<Friend>>,
-    #[serde(skip)]
-    friends_is_public: HashMap<SteamID, bool>, // True if public, False if private, no entry if we haven't checked yet.
-}
-
-pub struct Players {
-    all: HashMap<SteamID, Player>,
-    connected: Vec<SteamID>,
-    history: VecDeque<SteamID>,
-    records: PlayerRecords,
-}
-
-#[allow(dead_code)]
-impl Players {
-    fn new(records: PlayerRecords) -> Players {
-        Players {
-            all: HashMap::new(),
-            connected: Vec::new(),
-            history: VecDeque::with_capacity(MAX_HISTORY_LEN),
-            records,
-        }
-    }
-
-    pub fn all(&self) -> &HashMap<SteamID, Player> {
-        &self.all
-    }
-
-    pub fn get(&self, steamid: &SteamID) -> Option<&Player> {
-        self.all.get(&steamid)
-    }
-
-    fn get_mut(&mut self, steamid: &SteamID) -> Option<&mut Player> {
-        self.all.get_mut(steamid)
-    }
-
-    pub fn connected(&self) -> impl Iterator<Item = &Player> {
-        self.connected.iter().flat_map(|s| self.all.get(s))
-    }
-
-    fn connected_mut(&mut self) -> impl Iterator<Item = &mut Player> {
-        self.all
-            .iter_mut()
-            .filter(|(s, _)| self.connected.contains(s))
-            .map(&|(_, p)| p)
-    }
-
-    pub fn history(&self) -> impl Iterator<Item = &Player> {
-        self.history.iter().flat_map(|s| self.all.get(s))
-    }
-
-    pub fn has_record(&self, steamid: &SteamID) -> bool {
-        self.records.get_records().contains_key(&steamid)
-    }
-
-    pub fn insert_record(&mut self, record: PlayerRecord) {
-        self.records.insert_record(record);
-    }
-
-    pub fn records(&self) -> &PlayerRecords {
-        &self.records
-    }
-
-    pub fn record(&self, steamid: &SteamID) -> Option<&PlayerRecord> {
-        self.records.get_record(steamid)
-    }
-
-    pub fn record_mut(&mut self, steamid: &SteamID) -> Option<PlayerRecordLock> {
-        self.records.get_record_mut(steamid, &mut self.all)
-    }
-}
-
-impl Serialize for Players {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let connected: Vec<&Player> = self.connected().collect();
-        connected.serialize(serializer)
-    }
+    players: Players,
 }
 
 #[derive(Debug, Serialize, Clone)]
@@ -126,7 +38,6 @@ pub struct Gamemode {
 impl Server {
     pub fn new(playerlist: PlayerRecords) -> Server {
         Server {
-            user: None,
             map: None,
             ip: None,
             hostname: None,
@@ -135,20 +46,10 @@ impl Server {
             players: Players::new(playerlist),
 
             gamemode: None,
-            friends_lists: HashMap::new(),
-            friends_is_public: HashMap::new(),
         }
     }
 
     // **** Getters / Setters ****
-
-    pub fn user(&self) -> Option<SteamID> {
-        self.user
-    }
-
-    pub fn set_user(&mut self, user_id: Option<SteamID>) {
-        self.user = user_id;
-    }
 
     pub fn map(&self) -> Option<Arc<str>> {
         self.map.clone()
@@ -184,229 +85,6 @@ impl Server {
 }
 
 impl Server {
-    /// Moves any old players from the server into history. Any console commands (status, g15_dumpplayer, etc)
-    /// should be run before calling this function again to prevent removing all players from the player list.
-    pub fn refresh(&mut self) {
-        // Get old players
-        let unaccounted_players: Vec<SteamID> = self
-            .players
-            .connected()
-            .filter(|p| p.game_info.is_some() && p.game_info.as_ref().unwrap().should_prune())
-            .map(|p| p.steamid)
-            .collect();
-
-        self.players
-            .connected
-            .retain(|s| !unaccounted_players.contains(s));
-
-        // Remove any of them from the history as they will be added more recently
-        self.players
-            .history
-            .retain(|p| !unaccounted_players.iter().any(|up| up == p));
-
-        // Shrink to not go past max number of players
-        let num_players = self.players.history.len() + unaccounted_players.len();
-        for _ in MAX_HISTORY_LEN..num_players {
-            self.players.history.pop_front();
-        }
-
-        for p in unaccounted_players {
-            self.players.history.push_back(p);
-        }
-
-        // Mark all remaining players as unaccounted, they will be marked as accounted again
-        // when they show up in status or another console command.
-        self.players
-            .connected_mut()
-            .flat_map(|p| p.game_info.as_mut())
-            .for_each(GameInfo::next_cycle);
-    }
-
-    /// Add the provided SteamInfo to the given player. Returns true if that player was
-    /// found in the server.
-    pub fn insert_steam_info(&mut self, player: SteamID, info: SteamInfo) -> bool {
-        if let Some(player) = self.players.get_mut(&player) {
-            player.steam_info = Some(info.clone());
-            true
-        } else {
-            false
-        }
-    }
-
-    /// Updates friends lists of a user
-    /// Propagates to all other friends lists to ensure two-way lookup possible.
-    /// Only call if friends list was obtained directly from Steam API (i.e. friends list is public)
-    pub fn update_friends_list(&mut self, steamid: SteamID, friendslist: Vec<Friend>) {
-        self.friends_is_public.insert(steamid, true);
-
-        let oldfriends = self.friends_lists.insert(steamid, friendslist.clone());
-
-        // Propagate to all other hashmap entries
-        for friend in friendslist.clone() {
-            match self.friends_lists.get_mut(&friend.steamid) {
-                // Friend's friendlist in memory
-                Some(friends_of_friend) => {
-                    match friends_of_friend.iter().position(|f| f.steamid == steamid) {
-                        Some(friend_index) => {
-                            // player already in friend's friends list, update friend_since in case it changed.
-                            friends_of_friend[friend_index].friend_since = friend.friend_since;
-                        }
-                        None => {
-                            friends_of_friend.push(Friend {
-                                steamid,
-                                friend_since: friend.friend_since,
-                            });
-                        }
-                    }
-                }
-                // Friend's friendlist isn't in memory yet; create a new vector with player.
-                None => {
-                    let mut friends_of_friend = Vec::new();
-                    friends_of_friend.push(Friend {
-                        steamid,
-                        friend_since: friend.friend_since,
-                    });
-                    self.friends_lists.insert(friend.steamid, friends_of_friend);
-                }
-            }
-            self.update_friends_playerobj(&friend.steamid, None);
-        }
-
-        // If a player's friend has been unfriended, remove player from friend's hashmap
-        match oldfriends {
-            Some(oldfriends) => {
-                let oldfriends_ids = oldfriends
-                    .iter()
-                    .map(|f| f.steamid)
-                    .filter(|fid| friendslist.iter().find(|f| f.steamid == *fid).is_none());
-                for oldfriend_id in oldfriends_ids {
-                    self.remove_from_friends_list(&oldfriend_id, &steamid);
-                }
-            }
-            None => {}
-        }
-        self.update_friends_playerobj(&steamid, None);
-    }
-
-    /// Mark a friends list as being private, trim all now-stale information.
-    pub fn private_friends_list(&mut self, steamid: &SteamID) {
-        let old_vis_state = self.friends_is_public.insert(*steamid, false);
-        let old_friendslist = self.friends_lists.get(steamid).cloned();
-
-        match (old_vis_state, old_friendslist) {
-            (Some(old_vis_state), Some(old_friendslist)) => {
-                // Already processed, this function is the only one that sets friends lists to private.
-                if old_vis_state == false {
-                    return;
-                }
-
-                for friend in old_friendslist {
-                    let friends_of_friend = self.friends_lists.get(&friend.steamid);
-                    match (
-                        self.friends_is_public.get(&friend.steamid),
-                        friends_of_friend,
-                    ) {
-                        // If friend doesn't have any friends on record, nothing to remove.
-                        (_, None) => {
-                            continue;
-                        }
-                        (is_public, Some(_)) => {
-                            // If friend's friendlist is public, that information isn't stale.
-                            if is_public.is_some_and(|p| *p) {
-                                continue;
-                            }
-                            self.remove_from_friends_list(&friend.steamid, &steamid);
-                        }
-                    }
-                }
-            }
-            _ => {}
-        }
-        self.update_friends_playerobj(steamid, None);
-    }
-
-    /// Helper function to remove a friend from a player's friendlist.
-    fn remove_from_friends_list(&mut self, steamid: &SteamID, friend_to_remove: &SteamID) {
-        match self.friends_lists.get_mut(steamid) {
-            Some(friends) => match friends.iter().position(|f| f.steamid == *friend_to_remove) {
-                Some(i) => {
-                    friends.remove(i);
-                    self.update_friends_playerobj(&steamid, None);
-                }
-                None => {}
-            },
-            None => {}
-        }
-    }
-
-    /// Helper function to update the player object with the friends information we have on them.
-    fn update_friends_playerobj(
-        &mut self,
-        steamid: &SteamID,
-        existing_player: Option<&mut Player>,
-    ) {
-        let friends = self.friends_lists.get(steamid);
-        let friends_is_public = self.friends_is_public.get(steamid);
-
-        let mut player = self.players.get_mut(&steamid);
-
-        if existing_player.is_some() {
-            player = existing_player;
-        }
-
-        if player.is_some() && friends.is_some() {
-            player.unwrap().update_friends(
-                friends.unwrap().to_vec(),
-                friends_is_public.copied(),
-                self.user,
-            );
-        }
-    }
-
-    /// Return all known friends of a user, as well as their friend's list visibility as a bool.
-    pub fn get_friends_list(&self, steamid: &SteamID) -> (Option<&Vec<Friend>>, Option<&bool>) {
-        let friends = self.friends_lists.get(steamid);
-        let is_public = self.friends_is_public.get(steamid);
-
-        return (friends, is_public);
-    }
-
-    /// Check if an account is friends with the user.
-    /// Returns None if we don't have enough information to tell.
-    pub fn is_friends_with_user(&self, friend: &SteamID) -> Option<bool> {
-        if self.user.is_none() {
-            return None;
-        }
-        let user = self.user.unwrap();
-        return self.is_friends(friend, &user);
-    }
-
-    /// Check if two accounts are friends with each other.
-    /// Returns None if we don't have enough information to tell.
-    pub fn is_friends(&self, friend1: &SteamID, friend2: &SteamID) -> Option<bool> {
-        let ispublic_1 = self.friends_is_public.get(friend1);
-        let ispublic_2 = self.friends_is_public.get(friend2);
-
-        // If both friends lists are private, we can't say for sure.
-        if !ispublic_1.is_some_and(|p| *p) && !ispublic_2.is_some_and(|p| *p) {
-            return None;
-        }
-
-        let friends_list_1 = self.friends_lists.get(friend1);
-        let friends_list_2 = self.friends_lists.get(friend2);
-
-        match (friends_list_1, friends_list_2) {
-            (Some(friends_list_1), _) => {
-                return Some(friends_list_1.iter().any(|f| f.steamid == *friend2));
-            }
-            (_, Some(friends_list_2)) => {
-                return Some(friends_list_2.iter().any(|f| f.steamid == *friend1));
-            }
-            _ => {}
-        }
-        return Some(false);
-    }
-
     // **** Message handling ****
 
     /// Handles any io output from running commands / reading the console log file.
@@ -444,7 +122,6 @@ impl Server {
 
     fn handle_g15_parse(&mut self, players: Vec<g15::G15Player>) -> Vec<SteamID> {
         let mut new_players = Vec::new();
-        let mut name_updates: Vec<(SteamID, Arc<str>)> = Vec::new();
         for g15 in players {
             if g15.steamid.is_none() {
                 continue;
@@ -456,67 +133,22 @@ impl Server {
                 self.players.connected.push(steamid);
             }
 
-            if let Some(player) = self.players.get_mut(&steamid) {
-                if player.game_info.is_none() {
-                    player.game_info = GameInfo::new_from_g15(&g15);
-                }
-
-                if let Some(name) = g15.name {
-                    player.name = name;
-
-                    if !player.get_record().is_empty()
-                        && !player.previous_names.contains(&player.name)
-                    {
-                        name_updates.push((steamid, player.name.clone()));
+            // Update game info
+            if let Some(game_info) = self.players.game_info.get_mut(&steamid) {
+                if let Some(name) = g15.name.as_ref() {
+                    if *name != game_info.name {
+                        self.players.records.update_name(&steamid, name.clone());
                     }
                 }
+                game_info.update_from_g15(g15);
+            } else if let Some(game_info) = GameInfo::new_from_g15(g15) {
+                // Update name
+                self.players
+                    .records
+                    .update_name(&steamid, game_info.name.clone());
 
-                if let Some(game_info) = &mut player.game_info {
-                    // Update existing player
-                    if let Some(scr) = g15.score {
-                        game_info.kills = scr;
-                    }
-                    if let Some(dth) = g15.deaths {
-                        game_info.deaths = dth;
-                    }
-                    if let Some(png) = g15.ping {
-                        game_info.ping = png;
-                    }
-                    if let Some(tm) = g15.team {
-                        game_info.team = tm;
-                    }
-                    if let Some(uid) = g15.userid {
-                        game_info.userid = uid;
-                    }
-
-                    game_info.acknowledge();
-                }
-            } else {
-                // Create player data if they don't exist yet
-                if let Some(mut player) = Player::new_from_g15(&g15, self.user) {
-                    if let Some(mut record) = self.players.record_mut(&steamid) {
-                        if !record.previous_names.contains(&player.name) {
-                            record.previous_names.push(player.name.clone());
-                        }
-
-                        player.update_from_record(record.clone());
-                    }
-
-                    if self.is_friends_with_user(&steamid).is_some_and(|f| f) {
-                        player.tags.push(Arc::from("Friend"));
-                    }
-
-                    self.update_friends_playerobj(&steamid, Some(&mut player));
-                    self.players.all.insert(steamid, player);
-                    new_players.push(steamid);
-                }
-            }
-        }
-
-        // Update any recorded names
-        for (steamid, name) in name_updates {
-            if let Some(mut record) = self.players.record_mut(&steamid) {
-                record.previous_names.push(name);
+                self.players.game_info.insert(steamid, game_info);
+                new_players.push(steamid);
             }
         }
 
@@ -526,58 +158,32 @@ impl Server {
     /// Given a status line, update an existing or add a new one to the server.
     /// Returns the SteamID if a new player was created.
     fn handle_status_line(&mut self, status: StatusLine) -> Option<SteamID> {
+        let steamid = status.steamid;
+
         // Add to connected players if they aren't already
-        if !self.players.connected.contains(&status.steamid) {
-            self.players.connected.push(status.steamid);
+        if !self.players.connected.contains(&steamid) {
+            self.players.connected.push(steamid);
         }
 
-        // Update existing player or insert new player
-        if let Some(player) = self.players.get_mut(&status.steamid) {
-            // Update existing player
-            if player.game_info.is_none() {
-                player.game_info = Some(GameInfo::new_from_status(&status));
+        if let Some(game_info) = self.players.game_info.get_mut(&steamid) {
+            if status.name != game_info.name {
+                self.players
+                    .records
+                    .update_name(&steamid, status.name.clone());
             }
 
-            let game_info = player.game_info.as_mut().unwrap();
-            player.name = status.name;
-            game_info.userid = status.userid;
-            game_info.ping = status.ping;
-            game_info.loss = status.loss;
-            game_info.state = status.state;
-            game_info.time = status.time;
-            game_info.acknowledge();
-
-            // Update previous names
-            if !player.get_record().is_empty() && !player.previous_names.contains(&player.name) {
-                let new_name = player.name.clone();
-                if let Some(mut record) = self.players.record_mut(&status.steamid) {
-                    record.previous_names.push(new_name);
-                }
-            }
-
+            game_info.update_from_status(status);
             None
         } else {
-            // Create and insert new player
-            let mut player = Player::new_from_status(&status, self.user);
+            let game_info = GameInfo::new_from_status(status);
 
-            if let Some(mut record) = self.players.record_mut(&status.steamid) {
-                if !record.previous_names.contains(&player.name) {
-                    record.previous_names.push(player.name.clone());
-                }
+            // Update name
+            self.players
+                .records
+                .update_name(&steamid, game_info.name.clone());
 
-                player.update_from_record(record.clone());
-            }
-
-            if self
-                .is_friends_with_user(&status.steamid)
-                .is_some_and(|f| f)
-            {
-                player.tags.push(Arc::from("Friend"));
-            }
-
-            self.update_friends_playerobj(&status.steamid, Some(&mut player));
-            self.players.all.insert(status.steamid, player);
-            Some(status.steamid)
+            self.players.game_info.insert(steamid, game_info);
+            Some(steamid)
         }
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,7 +1,6 @@
 use serde::{Serialize, Serializer};
 use std::{
     collections::{HashMap, VecDeque},
-    ops::Range,
     sync::Arc,
 };
 use steamid_ng::SteamID;
@@ -23,16 +22,14 @@ const MAX_HISTORY_LEN: usize = 100;
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Server {
-    user_id: Option<SteamID>,
+    user: Option<SteamID>,
     map: Option<Arc<str>>,
     ip: Option<Arc<str>>,
     hostname: Option<Arc<str>>,
     max_players: Option<u32>,
     num_players: Option<u32>,
-    #[serde(serialize_with = "serialize_player_map")]
-    players: HashMap<SteamID, Player>,
-    #[serde(skip)]
-    player_history: VecDeque<Player>,
+    players: Players,
+
     gamemode: Option<Gamemode>,
 
     #[serde(skip)]
@@ -43,7 +40,61 @@ pub struct Server {
     friends_is_public: HashMap<SteamID, bool>, // True if public, False if private, no entry if we haven't checked yet.
 }
 
-#[derive(Debug, Serialize)]
+pub struct Players {
+    all: HashMap<SteamID, Player>,
+    connected: Vec<SteamID>,
+    history: VecDeque<SteamID>,
+}
+
+#[allow(dead_code)]
+impl Players {
+    fn new() -> Players {
+        Players {
+            all: HashMap::new(),
+            connected: Vec::new(),
+            history: VecDeque::with_capacity(MAX_HISTORY_LEN),
+        }
+    }
+
+    pub fn all(&self) -> &HashMap<SteamID, Player> {
+        &self.all
+    }
+
+    pub fn get(&self, steamid: &SteamID) -> Option<&Player> {
+        self.all.get(&steamid)
+    }
+
+    fn get_mut(&mut self, steamid: &SteamID) -> Option<&mut Player> {
+        self.all.get_mut(steamid)
+    }
+
+    pub fn connected(&self) -> impl Iterator<Item = &Player> {
+        self.connected.iter().flat_map(|s| self.all.get(s))
+    }
+
+    fn connected_mut(&mut self) -> impl Iterator<Item = &mut Player> {
+        self.all
+            .iter_mut()
+            .filter(|(s, _)| self.connected.contains(s))
+            .map(&|(_, p)| p)
+    }
+
+    pub fn history(&self) -> impl Iterator<Item = &Player> {
+        self.history.iter().flat_map(|s| self.all.get(s))
+    }
+}
+
+impl Serialize for Players {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let connected: Vec<&Player> = self.connected().collect();
+        connected.serialize(serializer)
+    }
+}
+
+#[derive(Debug, Serialize, Clone)]
 pub struct Gamemode {
     pub matchmaking: bool,
     #[serde(rename = "type")]
@@ -51,38 +102,322 @@ pub struct Gamemode {
     pub vanilla: bool,
 }
 
+#[allow(dead_code)]
 impl Server {
     pub fn new(playerlist: PlayerRecords) -> Server {
         Server {
-            user_id: None,
+            user: None,
             map: None,
             ip: None,
             hostname: None,
             max_players: None,
             num_players: None,
-            players: HashMap::new(),
-            player_history: VecDeque::with_capacity(MAX_HISTORY_LEN),
+            players: Players::new(),
+
             gamemode: None,
             player_records: playerlist,
             friends_lists: HashMap::new(),
-            friends_is_public: HashMap::new()
+            friends_is_public: HashMap::new(),
         }
     }
 
-    pub fn set_steam_user(&mut self, user_id: &Option<SteamID>) {
-        self.user_id = user_id.clone();
+    // **** Getters / Setters ****
+
+    pub fn user(&self) -> Option<SteamID> {
+        self.user
     }
+
+    pub fn set_user(&mut self, user_id: Option<SteamID>) {
+        self.user = user_id;
+    }
+
+    pub fn map(&self) -> Option<Arc<str>> {
+        self.map.clone()
+    }
+
+    pub fn ip(&self) -> Option<Arc<str>> {
+        self.ip.clone()
+    }
+
+    pub fn hostname(&self) -> Option<Arc<str>> {
+        self.hostname.clone()
+    }
+
+    pub fn max_players(&self) -> Option<u32> {
+        self.max_players
+    }
+
+    pub fn num_players(&self) -> Option<u32> {
+        self.num_players
+    }
+
+    pub fn players(&self) -> &Players {
+        &self.players
+    }
+
+    pub fn gamemode(&self) -> Option<&Gamemode> {
+        self.gamemode.as_ref()
+    }
+}
+
+impl Server {
+    /// Moves any old players from the server into history. Any console commands (status, g15_dumpplayer, etc)
+    /// should be run before calling this function again to prevent removing all players from the player list.
+    pub fn refresh(&mut self) {
+        // Get old players
+        let unaccounted_players: Vec<SteamID> = self
+            .players
+            .connected()
+            .filter(|p| p.game_info.should_prune())
+            .map(|p| p.steamid)
+            .collect();
+
+        self.players
+            .connected
+            .retain(|s| !unaccounted_players.contains(s));
+
+        // Remove any of them from the history as they will be added more recently
+        self.players
+            .history
+            .retain(|p| !unaccounted_players.iter().any(|up| up == p));
+
+        // Shrink to not go past max number of players
+        let num_players = self.players.history.len() + unaccounted_players.len();
+        for _ in MAX_HISTORY_LEN..num_players {
+            self.players.history.pop_front();
+        }
+
+        for p in unaccounted_players {
+            self.players.history.push_back(p);
+        }
+
+        // Mark all remaining players as unaccounted, they will be marked as accounted again
+        // when they show up in status or another console command.
+        for p in self.players.all.values_mut() {
+            p.game_info.next_cycle();
+        }
+    }
+
+    /// Add the provided SteamInfo to the given player. Returns true if that player was
+    /// found in the server.
+    pub fn insert_steam_info(&mut self, player: SteamID, info: SteamInfo) -> bool {
+        if let Some(player) = self.players.get_mut(&player) {
+            player.steam_info = Some(info.clone());
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Updates friends lists of a user
+    /// Propagates to all other friends lists to ensure two-way lookup possible.
+    /// Only call if friends list was obtained directly from Steam API (i.e. friends list is public)
+    pub fn update_friends_list(&mut self, steamid: SteamID, friendslist: Vec<Friend>) {
+        self.friends_is_public.insert(steamid, true);
+
+        let oldfriends = self.friends_lists.insert(steamid, friendslist.clone());
+
+        // Propagate to all other hashmap entries
+        for friend in friendslist.clone() {
+            match self.friends_lists.get_mut(&friend.steamid) {
+                // Friend's friendlist in memory
+                Some(friends_of_friend) => {
+                    match friends_of_friend.iter().position(|f| f.steamid == steamid) {
+                        Some(friend_index) => {
+                            // player already in friend's friends list, update friend_since in case it changed.
+                            friends_of_friend[friend_index].friend_since = friend.friend_since;
+                        }
+                        None => {
+                            friends_of_friend.push(Friend {
+                                steamid,
+                                friend_since: friend.friend_since,
+                            });
+                        }
+                    }
+                }
+                // Friend's friendlist isn't in memory yet; create a new vector with player.
+                None => {
+                    let mut friends_of_friend = Vec::new();
+                    friends_of_friend.push(Friend {
+                        steamid,
+                        friend_since: friend.friend_since,
+                    });
+                    self.friends_lists.insert(friend.steamid, friends_of_friend);
+                }
+            }
+            self.update_friends_playerobj(&friend.steamid, None);
+        }
+
+        // If a player's friend has been unfriended, remove player from friend's hashmap
+        match oldfriends {
+            Some(oldfriends) => {
+                let oldfriends_ids = oldfriends
+                    .iter()
+                    .map(|f| f.steamid)
+                    .filter(|fid| friendslist.iter().find(|f| f.steamid == *fid).is_none());
+                for oldfriend_id in oldfriends_ids {
+                    self.remove_from_friends_list(&oldfriend_id, &steamid);
+                }
+            }
+            None => {}
+        }
+        self.update_friends_playerobj(&steamid, None);
+    }
+
+    /// Mark a friends list as being private, trim all now-stale information.
+    pub fn private_friends_list(&mut self, steamid: &SteamID) {
+        let old_vis_state = self.friends_is_public.insert(*steamid, false);
+        let old_friendslist = self.friends_lists.get(steamid).cloned();
+
+        match (old_vis_state, old_friendslist) {
+            (Some(old_vis_state), Some(old_friendslist)) => {
+                // Already processed, this function is the only one that sets friends lists to private.
+                if old_vis_state == false {
+                    return;
+                }
+
+                for friend in old_friendslist {
+                    let friends_of_friend = self.friends_lists.get(&friend.steamid);
+                    match (
+                        self.friends_is_public.get(&friend.steamid),
+                        friends_of_friend,
+                    ) {
+                        // If friend doesn't have any friends on record, nothing to remove.
+                        (_, None) => {
+                            continue;
+                        }
+                        (is_public, Some(_)) => {
+                            // If friend's friendlist is public, that information isn't stale.
+                            if is_public.is_some_and(|p| *p) {
+                                continue;
+                            }
+                            self.remove_from_friends_list(&friend.steamid, &steamid);
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+        self.update_friends_playerobj(steamid, None);
+    }
+
+    /// Helper function to remove a friend from a player's friendlist.
+    fn remove_from_friends_list(&mut self, steamid: &SteamID, friend_to_remove: &SteamID) {
+        match self.friends_lists.get_mut(steamid) {
+            Some(friends) => match friends.iter().position(|f| f.steamid == *friend_to_remove) {
+                Some(i) => {
+                    friends.remove(i);
+                    self.update_friends_playerobj(&steamid, None);
+                }
+                None => {}
+            },
+            None => {}
+        }
+    }
+
+    /// Helper function to update the player object with the friends information we have on them.
+    fn update_friends_playerobj(
+        &mut self,
+        steamid: &SteamID,
+        existing_player: Option<&mut Player>,
+    ) {
+        let friends = self.friends_lists.get(steamid);
+        let friends_is_public = self.friends_is_public.get(steamid);
+
+        let mut player = self.players.get_mut(&steamid);
+
+        if existing_player.is_some() {
+            player = existing_player;
+        }
+
+        if player.is_some() && friends.is_some() {
+            player.unwrap().update_friends(
+                friends.unwrap().to_vec(),
+                friends_is_public.copied(),
+                self.user,
+            );
+        }
+    }
+
+    /// Return all known friends of a user, as well as their friend's list visibility as a bool.
+    pub fn get_friends_list(&self, steamid: &SteamID) -> (Option<&Vec<Friend>>, Option<&bool>) {
+        let friends = self.friends_lists.get(steamid);
+        let is_public = self.friends_is_public.get(steamid);
+
+        return (friends, is_public);
+    }
+
+    /// Check if an account is friends with the user.
+    /// Returns None if we don't have enough information to tell.
+    pub fn is_friends_with_user(&self, friend: &SteamID) -> Option<bool> {
+        if self.user.is_none() {
+            return None;
+        }
+        let user = self.user.unwrap();
+        return self.is_friends(friend, &user);
+    }
+
+    /// Check if two accounts are friends with each other.
+    /// Returns None if we don't have enough information to tell.
+    pub fn is_friends(&self, friend1: &SteamID, friend2: &SteamID) -> Option<bool> {
+        let ispublic_1 = self.friends_is_public.get(friend1);
+        let ispublic_2 = self.friends_is_public.get(friend2);
+
+        // If both friends lists are private, we can't say for sure.
+        if !ispublic_1.is_some_and(|p| *p) && !ispublic_2.is_some_and(|p| *p) {
+            return None;
+        }
+
+        let friends_list_1 = self.friends_lists.get(friend1);
+        let friends_list_2 = self.friends_lists.get(friend2);
+
+        match (friends_list_1, friends_list_2) {
+            (Some(friends_list_1), _) => {
+                return Some(friends_list_1.iter().any(|f| f.steamid == *friend2));
+            }
+            (_, Some(friends_list_2)) => {
+                return Some(friends_list_2.iter().any(|f| f.steamid == *friend1));
+            }
+            _ => {}
+        }
+        return Some(false);
+    }
+
+    // Player records
+
+    pub fn has_player_record(&self, steamid: SteamID) -> bool {
+        self.player_records.get_records().contains_key(&steamid)
+    }
+
+    pub fn get_player_records(&self) -> &PlayerRecords {
+        &self.player_records
+    }
+
+    pub fn insert_player_record(&mut self, record: PlayerRecord) {
+        self.player_records.insert_record(record);
+    }
+
+    pub fn get_player_record(&self, steamid: SteamID) -> Option<&PlayerRecord> {
+        self.player_records.get_record(steamid)
+    }
+
+    pub fn get_player_record_mut(&mut self, steamid: SteamID) -> Option<PlayerRecordLock> {
+        self.player_records
+            .get_record_mut(steamid, &mut self.players.all)
+    }
+
+    // **** Message handling ****
 
     /// Handles any io output from running commands / reading the console log file.
     /// Returns:
     /// * Some<[SteamID]> of a player if they have been newly added to the server.
-    pub fn handle_io_output(&mut self, response: IOOutput, user: Option<SteamID>) -> Vec<SteamID> {
+    pub fn handle_io_output(&mut self, response: IOOutput) -> Vec<SteamID> {
         use IOOutput::*;
         match response {
-            G15(players) => return self.handle_g15_parse(players, user).into(),
+            G15(players) => return self.handle_g15_parse(players).into(),
             Status(status) => {
                 return self
-                    .handle_status_line(status, user)
+                    .handle_status_line(status)
                     .map(|s| vec![s])
                     .unwrap_or_default();
             }
@@ -106,300 +441,51 @@ impl Server {
         Vec::new()
     }
 
-    /// Moves any old players from the server into history. Any console commands (status, g15_dumpplayer, etc)
-    /// should be run before calling this function again to prevent removing all players from the player list.
-    pub fn refresh(&mut self) {
-        // Get old players
-        let mut unaccounted_players = Vec::new();
-        for (steamid, player) in &self.players {
-            if player.game_info.should_prune() {
-                unaccounted_players.push(*steamid);
-            }
-        }
-
-        let unaccounted_players: Vec<Player> = unaccounted_players
-            .into_iter()
-            .flat_map(|sid| self.players.remove(&sid))
-            .collect();
-
-        // Remove any of them from the history as they will be added more recently
-        self.player_history
-            .retain(|p| !unaccounted_players.iter().any(|up| up.steamid == p.steamid));
-
-        // Shrink to not go past max number of players
-        let num_players = self.player_history.len() + unaccounted_players.len();
-        for _ in MAX_HISTORY_LEN..num_players {
-            self.player_history.pop_front();
-        }
-
-        for p in unaccounted_players {
-            self.player_history.push_back(p);
-        }
-
-        // Mark all remaining players as unaccounted, they will be marked as accounted again
-        // when they show up in status or another console command.
-        for p in self.players.values_mut() {
-            p.game_info.next_cycle();
-        }
-    }
-
-    /// Add the provided SteamInfo to the given player. Returns true if that player was
-    /// found in the server.
-    pub fn insert_steam_info(&mut self, player: SteamID, info: SteamInfo) -> bool {
-        let mut found = false;
-
-        if let Some(player) = self.players.get_mut(&player) {
-            player.steam_info = Some(info.clone());
-            found = true;
-        }
-
-        if let Some(player) = self.player_history.iter_mut().find(|p| p.steamid == player) {
-            player.steam_info = Some(info);
-            found = true;
-        }
-
-        found
-    }
-
-    /// Updates friends lists of a user
-    /// Propagates to all other friends lists to ensure two-way lookup possible.
-    /// Only call if friends list was obtained directly from Steam API (i.e. friends list is public)
-    pub fn update_friends_list(&mut self, steamid: SteamID, friendslist: Vec<Friend>) {
-        self.friends_is_public.insert(steamid, true);
-
-        let oldfriends = self.friends_lists.insert(steamid, friendslist.clone());
-
-        // Propagate to all other hashmap entries
-        for friend in friendslist.clone() {
-            match self.friends_lists.get_mut(&friend.steamid) {
-                // Friend's friendlist in memory
-                Some(friends_of_friend) => {
-                    match friends_of_friend.iter().position(|f| f.steamid == steamid) {
-                        Some(friend_index) => {
-                            // player already in friend's friends list, update friend_since in case it changed.
-                            friends_of_friend[friend_index].friend_since = friend.friend_since;
-                        },
-                        None => {
-                            friends_of_friend.push(Friend { steamid, friend_since: friend.friend_since });
-                        }
-                    }
-                }
-                // Friend's friendlist isn't in memory yet; create a new vector with player.
-                None => {
-                    let mut friends_of_friend = Vec::new();
-                    friends_of_friend.push(Friend { steamid, friend_since: friend.friend_since });
-                    self.friends_lists.insert(friend.steamid, friends_of_friend);
-                }
-            }
-            self.update_friends_playerobj(&friend.steamid, None);
-        }
-
-        // If a player's friend has been unfriended, remove player from friend's hashmap
-        match oldfriends {
-            Some(oldfriends) => {
-                let oldfriends_ids = oldfriends.iter().map(|f| {
-                    f.steamid
-                }).filter(|fid| {
-                    friendslist.iter().find(|f| f.steamid == *fid).is_none()
-                });
-                for oldfriend_id in oldfriends_ids {
-                    self.remove_from_friends_list(&oldfriend_id, &steamid);
-                }
-            },
-            None => {}
-        }
-        self.update_friends_playerobj(&steamid, None);
-    }
-
-    /// Mark a friends list as being private, trim all now-stale information.
-    pub fn private_friends_list (&mut self, steamid: &SteamID) {
-        let old_vis_state = self.friends_is_public.insert(*steamid, false);
-        let old_friendslist = self.friends_lists.get(steamid).cloned();
-        
-        match (old_vis_state, old_friendslist) {
-            (Some(old_vis_state), Some(old_friendslist)) => {
-                // Already processed, this function is the only one that sets friends lists to private.
-                if old_vis_state == false { return; } 
-
-                for friend in old_friendslist {
-                    let friends_of_friend = self.friends_lists.get(&friend.steamid);
-                    match (self.friends_is_public.get(&friend.steamid), friends_of_friend){
-                        // If friend doesn't have any friends on record, nothing to remove.
-                        (_, None) => {
-                            continue;
-                        }
-                        (is_public, Some(_)) => {
-                            // If friend's friendlist is public, that information isn't stale.
-                            if is_public.is_some_and(|p| *p) {
-                                continue;
-                            }
-                            self.remove_from_friends_list(&friend.steamid, &steamid);
-                        }
-                    }
-                }
-            }
-            _ => {}
-        }
-        self.update_friends_playerobj(steamid, None);
-    }
-
-    /// Helper function to remove a friend from a player's friendlist.
-    fn remove_from_friends_list(&mut self, steamid: &SteamID, friend_to_remove: &SteamID) {
-        match self.friends_lists.get_mut(steamid) {
-            Some(friends) => {
-                match friends.iter().position(|f| f.steamid == *friend_to_remove) {
-                    Some(i) => {
-                        friends.remove(i);
-                        self.update_friends_playerobj(&steamid, None);
-                    },
-                    None => {}
-                }
-            }
-            None => {}
-        }
-    }
-
-    /// Helper function to update the player object with the friends information we have on them.
-    fn update_friends_playerobj(&mut self, steamid: &SteamID, existing_player: Option<&mut Player>) {
-        let friends = self.friends_lists.get(steamid);
-        let friends_is_public = self.friends_is_public.get(steamid);
-
-        let mut player = self.players.get_mut(&steamid);
-
-        if existing_player.is_some() {
-            player = existing_player;
-        }
-
-        if player.is_some() && friends.is_some() {
-            player.unwrap().update_friends(friends.unwrap().to_vec(), friends_is_public.copied(), self.user_id);
-        }
-    }
-
-    /// Return all known friends of a user, as well as their friend's list visibility as a bool.
-    pub fn get_friends_list(&self, steamid: &SteamID) -> (Option<&Vec<Friend>>, Option<&bool>) {
-        let friends = self.friends_lists.get(steamid);
-        let is_public = self.friends_is_public.get(steamid);
-
-        return (friends, is_public);
-    }
-
-    /// Check if an account is friends with the user.
-    /// Returns None if we don't have enough information to tell.
-    pub fn is_friends_with_user(&self, friend: &SteamID) -> Option<bool> {
-        if self.user_id.is_none() {
-            return None;
-        }
-        let user = self.user_id.unwrap();
-        return self.is_friends(friend, &user);
-    }
-
-    /// Check if two accounts are friends with each other.
-    /// Returns None if we don't have enough information to tell.
-    pub fn is_friends(&self, friend1: &SteamID, friend2: &SteamID) -> Option<bool> {
-        let ispublic_1 = self.friends_is_public.get(friend1);
-        let ispublic_2 = self.friends_is_public.get(friend2);
-
-        // If both friends lists are private, we can't say for sure.
-        if !ispublic_1.is_some_and(|p| *p) && !ispublic_2.is_some_and(|p| *p) {
-            return None;
-        }
-        
-        let friends_list_1 = self.friends_lists.get(friend1);
-        let friends_list_2 = self.friends_lists.get(friend2);
-
-        match (friends_list_1, friends_list_2) {
-            (Some(friends_list_1), _) => {
-                return Some(friends_list_1.iter().any(|f| {
-                    f.steamid == *friend2
-                }));
-            }
-            (_, Some(friends_list_2)) => {
-                return Some(friends_list_2.iter().any(|f| {
-                    f.steamid == *friend1
-                }));
-            }
-            _ => {}
-        }
-        return Some(false);
-    }
-
-    /// Retrieve the player history somewhere in the range 0..100
-    pub fn get_player_history(&self, range: Range<usize>) -> Vec<&Player> {
-        self.player_history
-            .iter()
-            .rev()
-            .skip(range.start)
-            .take(range.end - range.start)
-            .collect()
-    }
-
-    // Player records
-
-    pub fn has_player_record(&self, steamid: SteamID) -> bool {
-        self.player_records.get_records().contains_key(&steamid)
-    }
-
-    pub fn get_player_records(&self) -> &PlayerRecords {
-        &self.player_records
-    }
-
-    pub fn insert_player_record(&mut self, record: PlayerRecord) {
-        self.player_records.insert_record(record);
-    }
-
-    pub fn get_player_record(&self, steamid: SteamID) -> Option<&PlayerRecord> {
-        self.player_records.get_record(steamid)
-    }
-
-    pub fn get_player_record_mut(&mut self, steamid: SteamID) -> Option<PlayerRecordLock> {
-        self.player_records
-            .get_record_mut(steamid, &mut self.players, &mut self.player_history)
-    }
-
-    pub fn get_players(&self) -> &HashMap<SteamID, Player> {
-        &self.players
-    }
-
-    // Other
-
-    fn handle_g15_parse(
-        &mut self,
-        players: Vec<g15::G15Player>,
-        user: Option<SteamID>,
-    ) -> Vec<SteamID> {
+    fn handle_g15_parse(&mut self, players: Vec<g15::G15Player>) -> Vec<SteamID> {
         let mut new_players = Vec::new();
         let mut name_updates: Vec<(SteamID, Arc<str>)> = Vec::new();
-        for pl in players {
-            if let Some(steamid) = pl.steamid {
+        for g15 in players {
+            if g15.steamid.is_none() {
+                continue;
+            }
+            let steamid = g15.steamid.unwrap();
+
+            // Add to connected players if they aren't already
+            if !self.players.connected.contains(&steamid) {
+                self.players.connected.push(steamid);
+            }
+
+            if let Some(player) = self.players.get_mut(&steamid) {
                 // Update existing player
-                if let Some(player) = self.players.get_mut(&steamid) {
-                    if let Some(scr) = pl.score {
-                        player.game_info.kills = scr;
-                    }
-                    if let Some(name) = pl.name {
-                        player.name = name;
+                if let Some(scr) = g15.score {
+                    player.game_info.kills = scr;
+                }
+                if let Some(name) = g15.name {
+                    player.name = name;
 
-                        if self.player_records.get_records().contains_key(&steamid)
-                            && !player.previous_names.contains(&player.name)
-                        {
-                            name_updates.push((steamid, player.name.clone()));
-                        }
+                    if self.player_records.get_records().contains_key(&steamid)
+                        && !player.previous_names.contains(&player.name)
+                    {
+                        name_updates.push((steamid, player.name.clone()));
                     }
-                    if let Some(dth) = pl.deaths {
-                        player.game_info.deaths = dth;
-                    }
-                    if let Some(png) = pl.ping {
-                        player.game_info.ping = png;
-                    }
-                    if let Some(tm) = pl.team {
-                        player.game_info.team = tm;
-                    }
-                    if let Some(uid) = pl.userid {
-                        player.game_info.userid = uid;
-                    }
+                }
+                if let Some(dth) = g15.deaths {
+                    player.game_info.deaths = dth;
+                }
+                if let Some(png) = g15.ping {
+                    player.game_info.ping = png;
+                }
+                if let Some(tm) = g15.team {
+                    player.game_info.team = tm;
+                }
+                if let Some(uid) = g15.userid {
+                    player.game_info.userid = uid;
+                }
 
-                    player.game_info.acknowledge();
-                } else if let Some(mut player) = Player::new_from_g15(&pl, user) {
+                player.game_info.acknowledge();
+            } else {
+                // Create player data if they don't exist yet
+                if let Some(mut player) = Player::new_from_g15(&g15, self.user) {
                     if let Some(mut record) = self.get_player_record_mut(steamid) {
                         if !record.previous_names.contains(&player.name) {
                             record.previous_names.push(player.name.clone());
@@ -413,8 +499,7 @@ impl Server {
                     }
 
                     self.update_friends_playerobj(&steamid, Some(&mut player));
-
-                    self.players.insert(steamid, player);
+                    self.players.all.insert(steamid, player);
                     new_players.push(steamid);
                 }
             }
@@ -432,7 +517,12 @@ impl Server {
 
     /// Given a status line, update an existing or add a new one to the server.
     /// Returns the SteamID if a new player was created.
-    fn handle_status_line(&mut self, status: StatusLine, user: Option<SteamID>) -> Option<SteamID> {
+    fn handle_status_line(&mut self, status: StatusLine) -> Option<SteamID> {
+        // Add to connected players if they aren't already
+        if !self.players.connected.contains(&status.steamid) {
+            self.players.connected.push(status.steamid);
+        }
+
         // Update existing player or insert new player
         if let Some(player) = self.players.get_mut(&status.steamid) {
             // Update existing player
@@ -460,7 +550,7 @@ impl Server {
             None
         } else {
             // Create and insert new player
-            let mut player = Player::new_from_status(&status, user);
+            let mut player = Player::new_from_status(&status, self.user);
 
             if let Some(mut record) = self.get_player_record_mut(status.steamid) {
                 if !record.previous_names.contains(&player.name) {
@@ -470,13 +560,15 @@ impl Server {
                 player.update_from_record(record.clone());
             }
 
-            if self.is_friends_with_user(&status.steamid).is_some_and(|f| f) {
+            if self
+                .is_friends_with_user(&status.steamid)
+                .is_some_and(|f| f)
+            {
                 player.tags.push(Arc::from("Friend"));
             }
 
             self.update_friends_playerobj(&status.steamid, Some(&mut player));
-
-            self.players.insert(status.steamid, player);
+            self.players.all.insert(status.steamid, player);
             Some(status.steamid)
         }
     }
@@ -490,15 +582,4 @@ impl Server {
         // TODO
         tracing::debug!("Kill: {:?}", kill);
     }
-}
-
-// Useful
-
-fn serialize_player_map<S, K, V>(map: &HashMap<K, V>, s: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-    V: Serialize,
-{
-    let values: Vec<_> = map.values().collect();
-    values.serialize(s)
 }

--- a/src/web.rs
+++ b/src/web.rs
@@ -23,9 +23,9 @@ use tokio_stream::{wrappers::ReceiverStream, Stream};
 use crate::{
     io::{Command, IOManagerMessage},
     player::Player,
-    player_records::{PlayerRecord, Verdict},
+    player_records::Verdict,
     server::Server,
-    settings::{Settings, FriendsAPIUsage},
+    settings::{FriendsAPIUsage, Settings},
     steamapi::SteamAPIMessage,
 };
 
@@ -180,15 +180,7 @@ async fn put_user(
     let mut server = state.server.write().unwrap();
     for (k, v) in users.0 {
         // Insert record if it didn't exist
-        if !server.players().has_record(&k) {
-            server.players_mut().insert_record(PlayerRecord::new(k));
-        }
-
-        // Update record
-        let mut record = server
-            .players_mut()
-            .record_mut(&k)
-            .expect("Mutating player record that was just inserted.");
+        let record = server.players_mut().records.entry(k).or_default();
 
         if let Some(custom_data) = v.custom_data {
             record.custom_data = custom_data;
@@ -197,7 +189,13 @@ async fn put_user(
         if let Some(verdict) = v.local_verdict {
             record.verdict = verdict;
         }
+
+        if record.is_empty() {
+            server.players_mut().records.remove(&k);
+        }
     }
+
+    server.players().records.save_ok();
 
     (StatusCode::OK, HEADERS)
 }
@@ -327,12 +325,15 @@ async fn get_history(State(state): AState, page: Query<Pagination>) -> impl Into
     tracing::debug!("History requested");
 
     let server = state.server.read().unwrap();
-    let history: Vec<&Player> = server.players().history().collect();
-    let history: Vec<&Player> = history
-        .into_iter()
+    // let hVecDeque<SteamID> = &server.players().history;
+    let history: Vec<Player> = server
+        .players()
+        .history
+        .iter()
         .rev()
         .skip(page.0.from)
         .take(page.0.to - page.0.from)
+        .flat_map(|s| server.players().get_serializable_player(s))
         .collect();
 
     (
@@ -348,7 +349,7 @@ async fn get_playerlist(State(state): AState) -> impl IntoResponse {
     (
         StatusCode::OK,
         HEADERS,
-        serde_json::to_string(&state.server.read().unwrap().players().records())
+        serde_json::to_string(&state.server.read().unwrap().players().records)
             .expect("Serialize player records"),
     )
 }

--- a/src/web.rs
+++ b/src/web.rs
@@ -180,13 +180,14 @@ async fn put_user(
     let mut server = state.server.write().unwrap();
     for (k, v) in users.0 {
         // Insert record if it didn't exist
-        if !server.has_player_record(k) {
-            server.insert_player_record(PlayerRecord::new(k));
+        if !server.players().has_record(&k) {
+            server.players_mut().insert_record(PlayerRecord::new(k));
         }
 
         // Update record
         let mut record = server
-            .get_player_record_mut(k)
+            .players_mut()
+            .record_mut(&k)
             .expect("Mutating player record that was just inserted.");
 
         if let Some(custom_data) = v.custom_data {
@@ -347,7 +348,7 @@ async fn get_playerlist(State(state): AState) -> impl IntoResponse {
     (
         StatusCode::OK,
         HEADERS,
-        serde_json::to_string(&state.server.read().unwrap().get_player_records())
+        serde_json::to_string(&state.server.read().unwrap().players().records())
             .expect("Serialize player records"),
     )
 }


### PR DESCRIPTION
This branch keeps all the player info stored separately (split into 5 parts, the game info, steam info, friend info, records, and tags), but in one unified cache. This keeps all the players stored in a single place instead of having them spread across one map for connected players, and a list for history. Doing it this way means we have more flexibility in how we handle players:
* Player info can be stored even if they weren't connected to a server (e.g. steam by api lookups)
* Player info can be stored even if they *were* connected to the server but have since been disconnected and kicked out of the history list.
* Don't have to sync anything between connected and previous players as they all access the same structure
* Simplifies accessing player info

One downside currently is that players will no longer be removed from the cache after a while, they will just accumulate. While it's currently unlikely anybody will have the app running long enough for this to be a problem, it would probably be a good idea to implement some sort of LRU policy and occasionally clear out the players (of course keeping anybody who is still in the connected or history list unconditionally).