### PR TITLE
Megascatterbomb/friend check api

### DIFF
--- a/src/player.rs
+++ b/src/player.rs
@@ -29,6 +29,9 @@ pub struct Player {
     pub convicted: bool,
     #[serde(rename = "previousNames")]
     pub previous_names: Vec<Arc<str>>,
+    pub friends: Vec<Friend>,
+    #[serde(rename = "friendsIsPublic")]
+    pub friends_is_public: Option<bool>,
 }
 
 impl Player {
@@ -45,6 +48,8 @@ impl Player {
             local_verdict: Verdict::Player,
             convicted: false,
             previous_names: Vec::new(),
+            friends: Vec::new(),
+            friends_is_public: None,
         }
     }
 
@@ -64,6 +69,8 @@ impl Player {
             local_verdict: Verdict::Player,
             convicted: false,
             previous_names: Vec::new(),
+            friends: Vec::new(),
+            friends_is_public: None,
         })
     }
 
@@ -77,6 +84,11 @@ impl Player {
         self.custom_data = record.custom_data;
         self.local_verdict = record.verdict;
         self.previous_names = record.previous_names;
+    }
+
+    pub fn update_friends(&mut self, friends: Vec<Friend>, is_public: Option<bool>) {
+        self.friends = friends;
+        self.friends_is_public = is_public;
     }
 
     /// Create a record from the current player

--- a/src/player.rs
+++ b/src/player.rs
@@ -86,9 +86,23 @@ impl Player {
         self.previous_names = record.previous_names;
     }
 
-    pub fn update_friends(&mut self, friends: Vec<Friend>, is_public: Option<bool>) {
+    pub fn update_friends(&mut self, friends: Vec<Friend>, is_public: Option<bool>, userid: Option<SteamID>) {
         self.friends = friends;
         self.friends_is_public = is_public;
+        if userid.is_some() {
+            let userid = userid.unwrap();
+            let is_friends_with_user = self.friends.iter().any(|f| f.steamid == userid);
+            let has_friend_tag = self.tags.iter().any(|t| &*t.as_ref() == "Friend");
+            
+            if is_friends_with_user && !has_friend_tag {
+                self.tags.push(Arc::from("Friend"));
+            } else if !is_friends_with_user && has_friend_tag {
+                let i = self.tags.iter().position(|t| &*t.as_ref() == "Friend");
+                if i.is_some() {
+                    self.tags.remove(i.unwrap());
+                }
+            }
+        }
     }
 
     /// Create a record from the current player

--- a/src/player.rs
+++ b/src/player.rs
@@ -165,7 +165,7 @@ pub struct SteamInfo {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct Friend {
-    #[serde(rename = "steamID64")]
+    #[serde(rename = "steamID64", serialize_with = "serialize_steamid_as_string")]
     pub steamid: SteamID,
     #[serde(rename = "friendSince")]
     pub friend_since: u64,

--- a/src/server.rs
+++ b/src/server.rs
@@ -202,7 +202,7 @@ impl Server {
                     friendslist.iter().find(|f| f.steamid == *fid).is_none()
                 });
                 for oldfriend_id in oldfriends_ids {
-                    self.remove_from_friends_list(&oldfriend_id, &steamid)
+                    self.remove_from_friends_list(&oldfriend_id, &steamid);
                 }
             },
             None => {}
@@ -243,12 +243,13 @@ impl Server {
     }
 
     /// Helper function to remove a friend from a player's friendlist.
-    fn remove_from_friends_list(&mut self, player: &SteamID, friend_to_remove: &SteamID) {
-        match self.friends_lists.get_mut(player) {
+    fn remove_from_friends_list(&mut self, steamid: &SteamID, friend_to_remove: &SteamID) {
+        match self.friends_lists.get_mut(steamid) {
             Some(friends) => {
                 match friends.iter().position(|f| f.steamid == *friend_to_remove) {
                     Some(i) => {
                         friends.remove(i);
+                        self.update_friends_playerobj(&steamid);
                     },
                     None => {}
                 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -191,6 +191,7 @@ impl Server {
                     self.friends_lists.insert(friend.steamid, friends_of_friend);
                 }
             }
+            self.update_friends_playerobj(&friend.steamid, None);
         }
 
         // If a player's friend has been unfriended, remove player from friend's hashmap
@@ -270,7 +271,7 @@ impl Server {
         }
 
         if player.is_some() && friends.is_some() {
-            player.unwrap().update_friends(friends.unwrap().to_vec(), friends_is_public.copied());
+            player.unwrap().update_friends(friends.unwrap().to_vec(), friends_is_public.copied(), self.user_id);
         }
     }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -360,7 +360,7 @@ impl Default for Settings {
             tf2_directory: PathBuf::default(),
             rcon_password: "mac_rcon".into(),
             steam_api_key: "YOUR_API_KEY_HERE".into(),
-            friends_api_usage: FriendsAPIUsage::None, // TODO: Change to CheatersOnly once frontend impl complete.
+            friends_api_usage: FriendsAPIUsage::CheatersOnly,
             port: 3621,
             autolaunch_ui: false,
             override_tf2_dir: None,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -29,7 +29,7 @@ pub enum ConfigFilesError {
     #[error("{0:?}")]
     Other(#[from] anyhow::Error),
 }
-#[derive(Debug, Serialize,Deserialize, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Copy, Clone)]
 pub enum FriendsAPIUsage {
     None,
     CheatersOnly,


### PR DESCRIPTION
Related to https://github.com/MegaAntiCheat/MegaAntiCheat-UI/pull/34

Finishes friend list retrieval from the steam api.
Data is now copied to player objects for use by front end. TODO: Clean this up so we aren't duplicating data between server.rs and player.rs (to be handled by #87 )
Implements a setting to control when friends list info should be retrieved.
Functioning implementation of "Friend" tag.
Bug fixes in existing logic.