### PR TITLE
Add ability to change RCon port

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -18,6 +18,9 @@ pub struct Args {
     /// Override the configured/default rcon password
     #[arg(short, long)]
     pub rcon_pword: Option<String>,
+    /// Override the RCON port for connecting to the game
+    #[arg(long)]
+    pub rcon_port: Option<u16>,
     /// Override the configured Steam API key,
     #[arg(short, long)]
     pub api_key: Option<String>,

--- a/src/launchoptions.rs
+++ b/src/launchoptions.rs
@@ -81,8 +81,9 @@ impl LaunchOptions {
             }
         }
 
-        let launch_options_regex = Regex::new(r#"\t{6}"LaunchOptions"\t{2}"([(\-\w\%\!\@\^\&)\s]*)""#)
-            .expect("Constructing LaunchOptions regex");
+        let launch_options_regex =
+            Regex::new(r#"\t{6}"LaunchOptions"\t{2}"([(\-\w\%\!\@\^\&)\s]*)""#)
+                .expect("Constructing LaunchOptions regex");
 
         Ok(LaunchOptions {
             local_config: config_path,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,12 @@
-use args::Args;
-use clap::Parser;
-use steamid_ng::SteamID;
 use crate::player_records::Verdict;
 use crate::steamapi::SteamAPIResponse;
+use args::Args;
+use clap::Parser;
 use include_dir::{include_dir, Dir};
 use player_records::PlayerRecords;
 use server::Server;
 use steamapi::SteamAPIManager;
+use steamid_ng::SteamID;
 use tokio::select;
 use tokio::sync::mpsc::unbounded_channel;
 use web::{web_main, SharedState};
@@ -108,7 +108,8 @@ fn main() {
         }
     }
 
-    let port = settings.get_port();
+    let webui_port = settings.get_webui_port();
+    let rcon_port = settings.get_rcon_port();
     let playerlist = PlayerRecords::load_or_create(&args);
     playerlist.save_ok();
 
@@ -125,7 +126,7 @@ fn main() {
             // IO Manager
             let (io_send, io_recv) = unbounded_channel();
             let (mut io_recv, mut io_manager) =
-                IOManager::new(log_file_path, settings.get_rcon_password(), io_recv);
+                IOManager::new(log_file_path, settings.get_rcon_password(), rcon_port, io_recv);
 
             tokio::task::spawn(async move {
                 io_manager.io_loop().await;
@@ -133,7 +134,7 @@ fn main() {
 
             // Autolaunch UI
             if args.autolaunch_ui || settings.get_autolaunch_ui() {
-                if let Err(e) = open::that(Path::new(&format!("http://localhost:{}", port))) {
+                if let Err(e) = open::that(Path::new(&format!("http://localhost:{}", webui_port))) {
                     tracing::error!("Failed to open web browser: {:?}", e);
                 }
             }
@@ -171,7 +172,7 @@ fn main() {
                 settings: settings.clone(),
             };
             tokio::task::spawn(async move {
-                web_main(shared_state, port).await;
+                web_main(shared_state, webui_port).await;
             });
 
             // Main loop
@@ -186,7 +187,7 @@ fn main() {
             let mut need_all_friends_lists = false;
 
             loop {
-                
+
                 select! {
                     // IO output
                     io_output_iter = io_recv.recv() => {
@@ -224,7 +225,7 @@ fn main() {
                                                 }
                                             },
                                             _ => {}
-                                        }; 
+                                        };
                                     }
                                 };
                                 let i = inprogress_friendlist_req.iter().position(|id| *id == steamid);
@@ -309,10 +310,10 @@ fn main() {
                                 None => {
                                     return Some(*steamid);
                                 }
-                            }      
+                            }
                         }).collect();
                     }
-                    
+
                     steam_api_send
                         .send(steamapi::SteamAPIMessage::CheckFriends(queued_friendlist_req.clone()))
                         .unwrap();

--- a/src/player.rs
+++ b/src/player.rs
@@ -86,14 +86,19 @@ impl Player {
         self.previous_names = record.previous_names;
     }
 
-    pub fn update_friends(&mut self, friends: Vec<Friend>, is_public: Option<bool>, userid: Option<SteamID>) {
+    pub fn update_friends(
+        &mut self,
+        friends: Vec<Friend>,
+        is_public: Option<bool>,
+        userid: Option<SteamID>,
+    ) {
         self.friends = friends;
         self.friends_is_public = is_public;
         if userid.is_some() {
             let userid = userid.unwrap();
             let is_friends_with_user = self.friends.iter().any(|f| f.steamid == userid);
             let has_friend_tag = self.tags.iter().any(|t| &*t.as_ref() == "Friend");
-            
+
             if is_friends_with_user && !has_friend_tag {
                 self.tags.push(Arc::from("Friend"));
             } else if !is_friends_with_user && has_friend_tag {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -33,7 +33,7 @@ pub enum ConfigFilesError {
 pub enum FriendsAPIUsage {
     None,
     CheatersOnly,
-    All
+    All,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -48,7 +48,7 @@ pub struct Settings {
     friends_api_usage: FriendsAPIUsage,
     rcon_password: Arc<str>,
     steam_api_key: Arc<str>,
-    port: u16,
+    webui_port: u16,
     autolaunch_ui: bool,
     external: serde_json::Value,
     #[serde(skip)]
@@ -58,9 +58,10 @@ pub struct Settings {
     #[serde(skip)]
     override_steam_api_key: Option<Arc<str>>,
     #[serde(skip)]
-    override_port: Option<u16>,
+    override_webui_port: Option<u16>,
     #[serde(skip)]
     override_steam_user: Option<SteamID>,
+    rcon_port: u16,
 }
 
 #[allow(dead_code)]
@@ -195,8 +196,12 @@ impl Settings {
     /// make sure to add tracing for any values overridden!
     pub fn set_overrides(&mut self, args: &Args) {
         // Override (and log if) the Port used to host the middleware API (default 3621)
-        self.override_port = args.port.map(|val| {
-            tracing::info!("Overrode configured port value {:?}->{:?}", self.port, val);
+        self.override_webui_port = args.port.map(|val| {
+            tracing::info!(
+                "Overrode configured port value {:?}->{:?}",
+                self.webui_port,
+                val
+            );
             val
         });
         // Override (and log if) the RCON password. (default mac_rcon)
@@ -278,8 +283,8 @@ impl Settings {
             .unwrap_or(&self.rcon_password)
             .clone()
     }
-    pub fn get_port(&self) -> u16 {
-        self.override_port.unwrap_or(self.port)
+    pub fn get_webui_port(&self) -> u16 {
+        self.override_webui_port.unwrap_or(self.webui_port)
     }
     pub fn get_steam_api_key(&self) -> Arc<str> {
         self.override_steam_api_key
@@ -296,8 +301,8 @@ impl Settings {
     pub fn set_rcon_password(&mut self, pwd: Arc<str>) {
         self.rcon_password = pwd;
     }
-    pub fn set_port(&mut self, port: u16) {
-        self.port = port;
+    pub fn set_webui_port(&mut self, port: u16) {
+        self.webui_port = port;
     }
 
     pub fn get_autolaunch_ui(&self) -> bool {
@@ -322,6 +327,14 @@ impl Settings {
 
     pub fn get_friends_api_usage(&self) -> &FriendsAPIUsage {
         &self.friends_api_usage
+    }
+
+    pub fn get_rcon_port(&self) -> u16 {
+        self.rcon_port
+    }
+
+    pub fn set_rcon_port(&mut self, port: u16) {
+        self.rcon_port = port;
     }
 
     /// Attempts to find (and create) a directory to be used for configuration files
@@ -361,14 +374,15 @@ impl Default for Settings {
             rcon_password: "mac_rcon".into(),
             steam_api_key: "YOUR_API_KEY_HERE".into(),
             friends_api_usage: FriendsAPIUsage::CheatersOnly,
-            port: 3621,
+            webui_port: 3621,
             autolaunch_ui: false,
             override_tf2_dir: None,
             override_rcon_password: None,
             override_steam_api_key: None,
-            override_port: None,
+            override_webui_port: None,
             override_steam_user: None,
             external: serde_json::Value::Object(Map::new()),
+            rcon_port: 27015,
         }
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -51,6 +51,7 @@ pub struct Settings {
     webui_port: u16,
     autolaunch_ui: bool,
     external: serde_json::Value,
+    rcon_port: u16,
     #[serde(skip)]
     override_tf2_dir: Option<PathBuf>,
     #[serde(skip)]
@@ -61,7 +62,8 @@ pub struct Settings {
     override_webui_port: Option<u16>,
     #[serde(skip)]
     override_steam_user: Option<SteamID>,
-    rcon_port: u16,
+    #[serde(skip)]
+    override_rcon_port: Option<u16>,
 }
 
 #[allow(dead_code)]
@@ -231,6 +233,15 @@ impl Settings {
             );
             Arc::from(val.clone())
         });
+        // Override (and log if) the RCON port (default 27015)
+        self.override_rcon_port = args.rcon_port.map(|val| {
+            tracing::info!(
+                "Overrode configured RCON port value {:?}->{:?}",
+                self.webui_port,
+                val
+            );
+            val
+        });
     }
 
     /// Attempt to save the settings back to the loaded configuration file
@@ -330,7 +341,7 @@ impl Settings {
     }
 
     pub fn get_rcon_port(&self) -> u16 {
-        self.rcon_port
+        self.override_rcon_port.unwrap_or(self.rcon_port)
     }
 
     pub fn set_rcon_port(&mut self, port: u16) {
@@ -376,13 +387,14 @@ impl Default for Settings {
             friends_api_usage: FriendsAPIUsage::CheatersOnly,
             webui_port: 3621,
             autolaunch_ui: false,
+            rcon_port: 27015,
             override_tf2_dir: None,
             override_rcon_password: None,
             override_steam_api_key: None,
             override_webui_port: None,
             override_steam_user: None,
+            override_rcon_port: None,
             external: serde_json::Value::Object(Map::new()),
-            rcon_port: 27015,
         }
     }
 }

--- a/src/steamapi.rs
+++ b/src/steamapi.rs
@@ -31,7 +31,7 @@ pub enum SteamAPIMessage {
 
 pub enum SteamAPIResponse {
     SteamInfo((SteamID, SteamInfo)),
-    FriendLists((SteamID, Result<Vec<Friend>>))
+    FriendLists((SteamID, Result<Vec<Friend>>)),
 }
 
 pub struct SteamAPIManager {
@@ -99,7 +99,7 @@ impl SteamAPIManager {
                                     }
                                 }
                             }
-                            
+
                         }
                     }
                 },

--- a/src/web.rs
+++ b/src/web.rs
@@ -24,7 +24,7 @@ use crate::{
     io::{Command, IOManagerMessage},
     player_records::{PlayerRecord, Verdict},
     server::Server,
-    settings::{Settings, FriendsAPIUsage},
+    settings::{FriendsAPIUsage, Settings},
     steamapi::SteamAPIMessage,
 };
 
@@ -209,6 +209,7 @@ struct InternalPreferences {
     pub tf2_directory: Option<Arc<str>>,
     pub rcon_password: Option<Arc<str>>,
     pub steam_api_key: Option<Arc<str>>,
+    pub rcon_port: Option<u16>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -228,6 +229,7 @@ async fn get_prefs(State(state): AState) -> impl IntoResponse {
             tf2_directory: Some(settings.get_tf2_directory().to_string_lossy().into()),
             rcon_password: Some(settings.get_rcon_password().into()),
             steam_api_key: Some(settings.get_steam_api_key().into()),
+            rcon_port: Some(settings.get_rcon_port()),
         }),
         external: Some(settings.get_external_preferences().clone()),
     };
@@ -261,6 +263,13 @@ async fn put_prefs(State(state): AState, prefs: Json<Preferences>) -> impl IntoR
                 .send(IOManagerMessage::SetRconPassword(rcon_pwd.clone()))
                 .unwrap();
             settings.set_rcon_password(rcon_pwd);
+        }
+        if let Some(rcon_port) = internal.rcon_port {
+            state
+                .io
+                .send(IOManagerMessage::SetRconPort(rcon_port.clone()))
+                .unwrap();
+            settings.set_rcon_port(rcon_port);
         }
         if let Some(steam_api_key) = internal.steam_api_key {
             state

--- a/tests/test_g15.rs
+++ b/tests/test_g15.rs
@@ -1,4 +1,4 @@
-/* 
+/*
 use std::fs;
 #[path = "../src/io/g15.rs"]
 pub mod g15;


### PR DESCRIPTION
Closes #93

I've done everything mentioned in that issue, and it works for me. The needed data for integration with the Web UI is all there, so that just needs to be done there.

If there are any issues, I'm happy to work on them, or you can also commit to this branch. The fairly large diff is due to also fixing some `cargo fmt` stuff.