### PR TITLE
Warn instead of Error if game not started

### DIFF
--- a/src/io/command_manager.rs
+++ b/src/io/command_manager.rs
@@ -49,7 +49,11 @@ impl CommandManager {
                 CommandManagerMessage::RunCommand(cmd) => {
                     let cmd = format!("{}", cmd);
                     if let Err(e) = self.run_command(&cmd).await {
-                        tracing::error!("Failed to run command {}: {:?}", cmd, e);
+                        if e.root_cause().to_string() == "deadline has elapsed" {
+                            tracing::warn!("Expected if TF2 is not running: Failed to run command {}.  {:?}", cmd, e);
+                        } else {
+                            tracing::error!("Failed to run command {}: {:?}", cmd, e);
+                        }
                     }
                 }
                 CommandManagerMessage::SetRconPassword(password) => {


### PR DESCRIPTION
Some users are confused by the looping rcon timeout errors that occur when the game is closed. This PR changes those errors to better communicate expected behaviour.
 
Other errors (such as 1st error in image) remain untouched.
Rcon timeout errors (2nd and 3rd errors in image) are changed to warnings with guidance indicating that the warning is expected if TF2 is closed.

![image](https://github.com/MegaAntiCheat/client-backend/assets/55725012/29bf12a4-3eb2-4b83-9c10-4333e81d80e7)
