### PR TITLE
Fix tf2 directory override

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -225,13 +225,13 @@ impl Settings {
             Arc::from(val.clone())
         });
         // Override (and log if) the TF2 game directory. (Can be configured, but by default we search via steam library for it)
-        self.override_steam_api_key = args.tf2_dir.as_ref().map(|val| {
+        self.override_tf2_dir = args.tf2_dir.as_ref().map(|val| {
             tracing::info!(
                 "Overrode configured TF2 directory {:?}->{:?}",
                 self.tf2_directory,
                 val
             );
-            Arc::from(val.clone())
+            PathBuf::from(val.clone())
         });
         // Override (and log if) the RCON port (default 27015)
         self.override_rcon_port = args.rcon_port.map(|val| {


### PR DESCRIPTION
Simple fix to make the `--tf2-dir` work.

If the `--tf2-dir` parameter was set, it would override the steam api key causing the steam api to return a 203 status code and the program would not be able to find `tf/console.log`.