### PR TITLE
Fix logging spam and error handling to promote a better user experience and less spam

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -155,7 +155,7 @@ impl IOManager {
                 },
                 command_response = self.command_recv.recv() => {
                     let out = self.read_command_response(command_response.expect("Failed to receive command response"));
-                    if out.len() > 0 {
+                    if !out.is_empty() {
                         self.response_send.send(out).expect("Main loop ded");
                     }
                 },
@@ -201,7 +201,7 @@ impl IOManager {
 
         // Check for G15 output
         let players = self.parser.parse_g15(&response);
-        if players.len() > 0 {
+        if !players.is_empty() {
             out.push(IOOutput::G15(players));
         }
 
@@ -210,39 +210,39 @@ impl IOManager {
 
     fn read_log_line(&self, line: &str) -> Option<IOOutput> {
         // Match status
-        if let Some(caps) = self.regex_status.captures(&line) {
+        if let Some(caps) = self.regex_status.captures(line) {
             match StatusLine::parse(caps) {
                 Ok(status) => return Some(IOOutput::Status(status)),
                 Err(e) => tracing::error!("Error parsing status line: {:?}", e),
             }
         }
         // Match chat message
-        if let Some(caps) = self.regex_chat.captures(&line) {
+        if let Some(caps) = self.regex_chat.captures(line) {
             let chat = ChatMessage::parse(caps);
             return Some(IOOutput::Chat(chat));
         }
         // Match player kills
-        if let Some(caps) = self.regex_kill.captures(&line) {
+        if let Some(caps) = self.regex_kill.captures(line) {
             let kill = PlayerKill::parse(caps);
             return Some(IOOutput::Kill(kill));
         }
         // Match server hostname
-        if let Some(caps) = self.regex_hostname.captures(&line) {
+        if let Some(caps) = self.regex_hostname.captures(line) {
             let hostname = Hostname::parse(caps);
             return Some(IOOutput::Hostname(hostname));
         }
         // Match server IP
-        if let Some(caps) = self.regex_ip.captures(&line) {
+        if let Some(caps) = self.regex_ip.captures(line) {
             let ip = ServerIP::parse(caps);
             return Some(IOOutput::ServerIP(ip));
         }
         // Match server map
-        if let Some(caps) = self.regex_map.captures(&line) {
+        if let Some(caps) = self.regex_map.captures(line) {
             let map = Map::parse(caps);
             return Some(IOOutput::Map(map));
         }
         // Match server player count
-        if let Some(caps) = self.regex_playercount.captures(&line) {
+        if let Some(caps) = self.regex_playercount.captures(line) {
             let playercount = PlayerCount::parse(caps);
             return Some(IOOutput::PlayerCount(playercount));
         }

--- a/src/io/command_manager.rs
+++ b/src/io/command_manager.rs
@@ -1,8 +1,7 @@
-use std::{sync::Arc, time::Duration};
-use anyhow::ensure;
-use anyhow::{Context, Result};
+use anyhow::Result;
 use rcon::Connection;
-
+use std::{sync::Arc, time::Duration};
+use thiserror::Error;
 use tokio::{
     net::TcpStream,
     sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
@@ -10,6 +9,38 @@ use tokio::{
 };
 
 use super::Command;
+
+#[derive(Debug, Error)]
+pub enum CommandManagerError {
+    #[error("RCon error {0}")]
+    Rcon(#[from] rcon::Error),
+    #[error("Rcon connection timeout: {0}")]
+    TimeOut(#[from] tokio::time::error::Elapsed),
+    #[error("{0:?}")]
+    Other(#[from] anyhow::Error),
+}
+
+impl PartialEq for CommandManagerError {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Rcon(rcon::Error::Auth), Self::Rcon(rcon::Error::Auth)) => return true,
+            (Self::Rcon(rcon::Error::CommandTooLong), Self::Rcon(rcon::Error::CommandTooLong)) => {
+                return true
+            }
+            (Self::Rcon(rcon::Error::Io(_)), Self::Rcon(rcon::Error::Io(_))) => return true,
+            (Self::TimeOut(_), Self::TimeOut(_)) => return true,
+            (Self::Other(_), Self::Other(_)) => return true,
+            _ => return false,
+        }
+    }
+}
+
+#[derive(PartialEq)]
+enum ErrorState {
+    Never,
+    Okay,
+    Current(CommandManagerError),
+}
 
 pub enum CommandManagerMessage {
     RunCommand(Command),
@@ -21,7 +52,8 @@ pub struct CommandManager {
     rcon_password: Arc<str>,
     rcon: Option<Connection<TcpStream>>,
     rcon_port: u16,
-    rcon_connected: bool,
+    error_state: ErrorState,
+    error_hist: ErrorState,
     request_recv: UnboundedReceiver<CommandManagerMessage>,
     response_send: UnboundedSender<Arc<str>>,
 }
@@ -39,7 +71,8 @@ impl CommandManager {
             rcon_password,
             rcon: None,
             rcon_port,
-            rcon_connected: true, // Assume rcon connected until failure
+            error_state: ErrorState::Never,
+            error_hist: ErrorState::Never,
             request_recv: recv,
             response_send: resp_tx,
         };
@@ -49,46 +82,72 @@ impl CommandManager {
 
     /// Start the command manager loop. This will block until the channel is closed, so usually it should be spawned in a separate `tokio::task`
     pub async fn command_loop(&mut self) {
-        let mut error_printed: bool = false;
+        // let mut printed_for: ErrorState = ErrorState::Never;
         loop {
-            if !self.rcon_connected {
-                if let Err(e) = self.try_reconnect().await {
-                    if !error_printed {
-                        tracing::error!("Couldn't connect to RCON: {:?}", e);
-                        error_printed = true;
+            if self.error_state != self.error_hist {
+                match &self.error_state {
+                    ErrorState::Current(e @ CommandManagerError::TimeOut(_))
+                        if self.error_hist == ErrorState::Never =>
+                    {
+                        tracing::warn!("{}", e)
+                    }
+                    ErrorState::Current(err) => {
+                        tracing::error!("{}", err);
+                    }
+                    _ => {}
+                };
+            }
+
+            if self.error_state != ErrorState::Okay {
+                match self.try_reconnect().await {
+                    Ok(_) => {
+                        match self.error_state {
+                            ErrorState::Current(_) => {
+                                tracing::info!("Succesfully reconnected to RCon")
+                            }
+                            ErrorState::Never => {
+                                tracing::info!("Succesfully established a connection with RCon")
+                            }
+                            _ => {}
+                        };
+                        std::mem::swap(&mut self.error_state, &mut self.error_hist);
+                        self.error_state = ErrorState::Okay;
+                    } // :)
+                    Err(e) => {
+                        std::mem::swap(&mut self.error_state, &mut self.error_hist);
+                        self.error_state = ErrorState::Current(CommandManagerError::from(e));
                     }
                 }
             }
-            
-            match self.request_recv.recv().await.expect("The main IO Loop experienced a fatal error.") {
+
+            match self
+                .request_recv
+                .recv()
+                .await
+                .expect("The main IO Loop experienced a fatal error.")
+            {
                 CommandManagerMessage::RunCommand(cmd) => {
-                    if self.rcon_connected {
+                    if self.error_state == ErrorState::Okay {
                         let cmd = format!("{}", cmd);
                         if let Err(e) = self.run_command(&cmd).await {
                             tracing::error!("Failed to run command {}: {:?}", cmd, e);
-                            self.rcon_connected = false;
-                            error_printed = false;
+                            self.error_state = ErrorState::Current(CommandManagerError::from(e));
                         }
                     }
-                    
                 }
                 CommandManagerMessage::SetRconPassword(password) => {
                     self.rcon_password = password;
-                    self.rcon_connected = false;
-                    error_printed = false;
-                    
+                    self.error_state = ErrorState::Never;
                 }
                 CommandManagerMessage::SetRconPort(port) => {
                     self.rcon_port = port;
-                    self.rcon_connected = false;
-                    error_printed = false;
+                    self.error_state = ErrorState::Never;
                 }
             }
         }
     }
 
-    pub async fn run_command(&mut self, command: &str) -> Result<()> {
-        ensure!(self.rcon.as_mut().is_some(), "Couldn't reach RCON (no client).");
+    pub async fn run_command(&mut self, command: &str) -> Result<(), CommandManagerError> {
         let rcon = self.rcon.as_mut().unwrap();
 
         tracing::debug!("Running command \"{}\"", command);
@@ -98,19 +157,21 @@ impl CommandManager {
             .map_err(|e| {
                 self.rcon = None;
                 e
-            })
-            .context("Failed to run command")?
+            })?
             .into();
 
-        self.response_send
-            .send(result)
-            .expect("Couldn't send command response");
+        self.response_send.send(result).unwrap();
 
         Ok(())
     }
 
-    async fn try_reconnect(&mut self) -> Result<&mut Connection<TcpStream>> {
-        tracing::debug!("Attempting to reconnect to RCon");
+    async fn try_reconnect(&mut self) -> Result<(), CommandManagerError> {
+        match self.error_state {
+            ErrorState::Current(_) => tracing::debug!("Attempting to reconnect to RCon"),
+            ErrorState::Never => tracing::debug!("Attempting to connect to RCon"),
+            _ => {}
+        };
+
         match timeout(
             Duration::from_secs(2),
             Connection::connect(
@@ -122,19 +183,15 @@ impl CommandManager {
         {
             Ok(Ok(con)) => {
                 self.rcon = Some(con);
-                self.rcon_connected = true;
-                tracing::info!("RCon reconnected.");
-                Ok(self.rcon.as_mut().expect(""))
+                Ok(())
             }
             Ok(Err(e)) => {
                 self.rcon = None;
-                self.rcon_connected = false;
-                Err(e).context("Failed to establish connection")
+                Err(e.into())
             }
             Err(e) => {
                 self.rcon = None;
-                self.rcon_connected = false;
-                Err(e).context("RCon connection timed out")
+                Err(e.into())
             }
         }
     }

--- a/src/io/command_manager.rs
+++ b/src/io/command_manager.rs
@@ -22,15 +22,16 @@ pub enum CommandManagerError {
 
 impl PartialEq for CommandManagerError {
     fn eq(&self, other: &Self) -> bool {
+        #[allow(clippy::match_like_matches_macro)]
         match (self, other) {
-            (Self::Rcon(rcon::Error::Auth), Self::Rcon(rcon::Error::Auth)) => return true,
+            (Self::Rcon(rcon::Error::Auth), Self::Rcon(rcon::Error::Auth)) => true,
             (Self::Rcon(rcon::Error::CommandTooLong), Self::Rcon(rcon::Error::CommandTooLong)) => {
-                return true
+                true
             }
-            (Self::Rcon(rcon::Error::Io(_)), Self::Rcon(rcon::Error::Io(_))) => return true,
-            (Self::TimeOut(_), Self::TimeOut(_)) => return true,
-            (Self::Other(_), Self::Other(_)) => return true,
-            _ => return false,
+            (Self::Rcon(rcon::Error::Io(_)), Self::Rcon(rcon::Error::Io(_))) => true,
+            (Self::TimeOut(_), Self::TimeOut(_)) => true,
+            (Self::Other(_), Self::Other(_)) => true,
+            _ => false,
         }
     }
 }
@@ -115,7 +116,7 @@ impl CommandManager {
                     } // :)
                     Err(e) => {
                         std::mem::swap(&mut self.error_state, &mut self.error_hist);
-                        self.error_state = ErrorState::Current(CommandManagerError::from(e));
+                        self.error_state = ErrorState::Current(e);
                     }
                 }
             }
@@ -131,7 +132,7 @@ impl CommandManager {
                         let cmd = format!("{}", cmd);
                         if let Err(e) = self.run_command(&cmd).await {
                             tracing::error!("Failed to run command {}: {:?}", cmd, e);
-                            self.error_state = ErrorState::Current(CommandManagerError::from(e));
+                            self.error_state = ErrorState::Current(e);
                         }
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -307,7 +307,7 @@ fn main() {
                                     _ => {
                                         return Some(*steamid);
                                     }
-                                }      
+                                }
                             }).collect();
                     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -279,7 +279,7 @@ fn main() {
                 }
 
                 // Request friend lists of relevant players (depends on config)
-                if need_all_friends_lists || queued_friendlist_req.len() > 0 {
+                if need_all_friends_lists || queued_friendlist_req.is_empty() {
                     // If a cheater's friends list is private, we need everyone's friends list.
                     if need_all_friends_lists {
                         need_all_friends_lists = false;
@@ -292,7 +292,7 @@ fn main() {
                                 // If friends list visibility is Some, we've looked up that user before.
                                 match server_read.players().friend_info.get(steamid).map(|fi| fi.public) {
                                     Some(Some(true)) => {
-                                        return None;
+                                        None
                                     }
                                     Some(Some(false)) => {
                                         let record = server_read.players().records.get(steamid);
@@ -302,10 +302,10 @@ fn main() {
                                          }) {
                                             need_all_friends_lists = true;
                                         }
-                                        return None;
+                                        None
                                     }
                                     _ => {
-                                        return Some(*steamid);
+                                        Some(*steamid)
                                     }
                                 }
                             }).collect();

--- a/src/player.rs
+++ b/src/player.rs
@@ -63,7 +63,7 @@ impl Players {
     pub fn clear_tag(&mut self, steamid: SteamID, tag: &str) {
         if let Some(tags) = self.tags.get_mut(&steamid) {
             tags.remove(tag);
-            if tags.len() == 0 {
+            if tags.is_empty() {
                 self.tags.remove(&steamid);
             }
         }
@@ -152,7 +152,7 @@ impl Players {
                     continue;
                 }
 
-                self.remove_from_friends_list(&friend.steamid, &steamid);
+                self.remove_from_friends_list(&friend.steamid, steamid);
             }
         }
     }
@@ -267,7 +267,7 @@ impl Players {
             customData: record
                 .as_ref()
                 .map(|r| r.custom_data.clone())
-                .unwrap_or_else(|| default_custom_data()),
+                .unwrap_or_else(default_custom_data),
             convicted: false,
             tags,
             previous_names,
@@ -406,9 +406,7 @@ impl GameInfo {
     }
 
     pub(crate) fn new_from_g15(g15: G15Player) -> Option<GameInfo> {
-        if g15.userid.is_none() {
-            return None;
-        }
+        g15.userid.as_ref()?;
 
         let mut game_info = GameInfo::new();
         game_info.update_from_g15(g15);
@@ -483,19 +481,10 @@ pub struct Friend {
     pub friend_since: u64,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Default)]
 pub struct FriendInfo {
     pub public: Option<bool>,
     friends: Vec<Friend>,
-}
-
-impl Default for FriendInfo {
-    fn default() -> Self {
-        FriendInfo {
-            public: None,
-            friends: Vec::new(),
-        }
-    }
 }
 
 impl Deref for FriendInfo {

--- a/src/player_records.rs
+++ b/src/player_records.rs
@@ -43,7 +43,7 @@ impl PlayerRecords {
             tracing::error!("Could not find a suitable location for the playerlist: {} \nPlease specify a file path manually with --playerlist otherwise information may not be saved.", e); 
         }).unwrap_or(PathBuf::from("playerlist.json"));
 
-        let playerlist = match PlayerRecords::load_from(playerlist_path) {
+        match PlayerRecords::load_from(playerlist_path) {
             Ok(playerlist) => playerlist,
             Err(ConfigFilesError::Json(path, e)) => {
                 tracing::error!("{} could not be loaded: {:?}", path, e);
@@ -65,9 +65,7 @@ impl PlayerRecords {
                 );
                 panic!("Failed to load playerlist")
             }
-        };
-
-        playerlist
+        }
     }
 
     /// Attempt to load the [PlayerRecords] from the provided file

--- a/src/server.rs
+++ b/src/server.rs
@@ -93,7 +93,7 @@ impl Server {
     pub fn handle_io_output(&mut self, response: IOOutput) -> Vec<SteamID> {
         use IOOutput::*;
         match response {
-            G15(players) => return self.handle_g15_parse(players).into(),
+            G15(players) => return self.handle_g15_parse(players),
             Status(status) => {
                 return self
                     .handle_status_line(status)

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -83,7 +83,7 @@ impl Settings {
             tracing::error!("Could not find a suitable location for the configuration: {}\nPlease specify a file path manually with --config", e);
         }).unwrap_or(PathBuf::from("config.yaml"));
 
-        let mut settings = match Settings::load_from(settings_path, &args) {
+        let mut settings = match Settings::load_from(settings_path, args) {
             Ok(settings) => settings,
             Err(ConfigFilesError::Yaml(path, e)) => {
                 tracing::error!("{} could not be loaded: {:?}", path, e);
@@ -96,7 +96,7 @@ impl Settings {
                 tracing::warn!("Could not locate {}, creating new configuration.", &path);
                 let mut settings = Settings::default();
                 settings.set_config_path(path.into());
-                settings.set_overrides(&args);
+                settings.set_overrides(args);
                 settings
             }
             Err(e) => {

--- a/src/steamapi.rs
+++ b/src/steamapi.rs
@@ -78,7 +78,6 @@ impl SteamAPIManager {
         } else {
             tracing::info!("Updated SteamAPI key.");
         }
-        
     }
 
     /// Enter a loop to wait for steam lookup requests, make those requests from the Steam web API,
@@ -155,7 +154,6 @@ async fn request_steam_info(
     client: &mut SteamAPI,
     playerids: Vec<SteamID>,
 ) -> Result<Vec<(SteamID, SteamInfo)>> {
-
     tracing::debug!("Requesting steam accounts: {:?}", playerids);
 
     let summaries = request_player_summary(client, &playerids).await?;
@@ -284,11 +282,13 @@ async fn request_account_bans(
 }
 
 fn is_api_key_valid(api_key: &Arc<str>) -> bool {
-    // A valid steam API key is a 32 digit hexadecimal number. We store them as strings, so 
+    // A valid steam API key is a 32 digit hexadecimal number. We store them as strings, so
     // we check for exactly 32 hexadecimal ascii digits. Anything that doesn't fit this rule
     // is likely not a valid Steam API key (inb4 Valve changes the format on my ass)
-    return api_key.len() == 32 && 
-        api_key.chars()
-        .map(|c| c.is_ascii_hexdigit())
-        .reduce(|acc, e| acc && e).unwrap()
+    return api_key.len() == 32
+        && api_key
+            .chars()
+            .map(|c| c.is_ascii_hexdigit())
+            .reduce(|acc, e| acc && e)
+            .unwrap();
 }

--- a/src/steamapi.rs
+++ b/src/steamapi.rs
@@ -123,10 +123,8 @@ impl SteamAPIManager {
                     }
                 },
                 _ = batch_timer.tick() => {
-                    if self.api_key_valid {
-                        if !self.batch_buffer.is_empty() {
-                            self.send_batch().await;
-                        }
+                    if self.api_key_valid && !self.batch_buffer.is_empty() {
+                        self.send_batch().await;
                     }
                 }
             }

--- a/src/steamapi.rs
+++ b/src/steamapi.rs
@@ -37,6 +37,7 @@ pub enum SteamAPIResponse {
 pub struct SteamAPIManager {
     client: SteamAPI,
     batch_buffer: VecDeque<SteamID>,
+    api_key_valid: bool,
 
     request_recv: UnboundedReceiver<SteamAPIMessage>,
     response_send: UnboundedSender<SteamAPIResponse>,
@@ -49,9 +50,15 @@ impl SteamAPIManager {
     ) -> (UnboundedReceiver<SteamAPIResponse>, SteamAPIManager) {
         let (resp_tx, resp_rx) = unbounded_channel();
 
+        let valid_api_key = is_api_key_valid(&api_key);
+        if !valid_api_key {
+            tracing::info!("Invalid/Improper API key provided, disabling Steam API requests.");
+        }
+
         let api_manager = SteamAPIManager {
             client: SteamAPI::new(api_key),
             batch_buffer: VecDeque::with_capacity(BATCH_SIZE),
+            api_key_valid: valid_api_key,
 
             request_recv: recv,
             response_send: resp_tx,
@@ -61,7 +68,17 @@ impl SteamAPIManager {
     }
 
     fn set_api_key(&mut self, api_key: Arc<str>) {
+        let _last = self.api_key_valid;
+        self.api_key_valid = is_api_key_valid(&api_key);
         self.client = SteamAPI::new(api_key);
+        if !_last && self.api_key_valid {
+            tracing::info!("New API key received, enabling SteamAPI requests.");
+        } else if _last && !self.api_key_valid {
+            tracing::info!("Invalid/Improper API key received, disabling SteamAPI requests.");
+        } else {
+            tracing::info!("Updated SteamAPI key.");
+        }
+        
     }
 
     /// Enter a loop to wait for steam lookup requests, make those requests from the Steam web API,
@@ -78,34 +95,39 @@ impl SteamAPIManager {
                             self.set_api_key(key);
                         },
                         SteamAPIMessage::Lookup(steamid) => {
-                            self.batch_buffer.push_back(steamid);
-                            if self.batch_buffer.len() >= BATCH_SIZE {
-                                self.send_batch().await;
-                                batch_timer.reset();  // Reset the timer
+                            if self.api_key_valid {
+                                self.batch_buffer.push_back(steamid);
+                                if self.batch_buffer.len() >= BATCH_SIZE {
+                                    self.send_batch().await;
+                                    batch_timer.reset();  // Reset the timer
+                                }
                             }
                         },
                         SteamAPIMessage::CheckFriends(steamids) => {
-                            for id in steamids {
-                                match request_account_friends(&mut self.client, id).await {
-                                    Ok(friends) => {
-                                        self.response_send
-                                            .send(SteamAPIResponse::FriendLists((id, Ok(friends))))
-                                            .expect("Lost connection to main thread.");
-                                    }
-                                    Err(err) => {
-                                        self.response_send
-                                            .send(SteamAPIResponse::FriendLists((id, Err(err))))
-                                            .expect("Lost connection to main thread.");
+                            if self.api_key_valid {
+                                for id in steamids {
+                                    match request_account_friends(&mut self.client, id).await {
+                                        Ok(friends) => {
+                                            self.response_send
+                                                .send(SteamAPIResponse::FriendLists((id, Ok(friends))))
+                                                .expect("Lost connection to main thread.");
+                                        }
+                                        Err(err) => {
+                                            self.response_send
+                                                .send(SteamAPIResponse::FriendLists((id, Err(err))))
+                                                .expect("Lost connection to main thread.");
+                                        }
                                     }
                                 }
                             }
-
                         }
                     }
                 },
                 _ = batch_timer.tick() => {
-                    if !self.batch_buffer.is_empty() {
-                        self.send_batch().await;
+                    if self.api_key_valid {
+                        if !self.batch_buffer.is_empty() {
+                            self.send_batch().await;
+                        }
                     }
                 }
             }
@@ -133,6 +155,7 @@ async fn request_steam_info(
     client: &mut SteamAPI,
     playerids: Vec<SteamID>,
 ) -> Result<Vec<(SteamID, SteamInfo)>> {
+
     tracing::debug!("Requesting steam accounts: {:?}", playerids);
 
     let summaries = request_player_summary(client, &playerids).await?;
@@ -258,4 +281,11 @@ async fn request_account_bans(
     let bans = serde_json::from_str::<GetPlayerBansResponseBase>(&bans)
         .with_context(|| format!("Failed to parse player bans from SteamAPI: {}", &bans))?;
     Ok(bans.players)
+}
+
+fn is_api_key_valid(api_key: &Arc<str>) -> bool {
+    return api_key.len() == 32 && 
+        api_key.chars()
+        .map(|c| c.is_ascii_hexdigit())
+        .reduce(|acc, e| acc && e).unwrap()
 }

--- a/src/steamapi.rs
+++ b/src/steamapi.rs
@@ -284,6 +284,9 @@ async fn request_account_bans(
 }
 
 fn is_api_key_valid(api_key: &Arc<str>) -> bool {
+    // A valid steam API key is a 32 digit hexadecimal number. We store them as strings, so 
+    // we check for exactly 32 hexadecimal ascii digits. Anything that doesn't fit this rule
+    // is likely not a valid Steam API key (inb4 Valve changes the format on my ass)
     return api_key.len() == 32 && 
         api_key.chars()
         .map(|c| c.is_ascii_hexdigit())

--- a/src/web.rs
+++ b/src/web.rs
@@ -227,8 +227,8 @@ async fn get_prefs(State(state): AState) -> impl IntoResponse {
         internal: Some(InternalPreferences {
             friends_api_usage: Some(*settings.get_friends_api_usage()),
             tf2_directory: Some(settings.get_tf2_directory().to_string_lossy().into()),
-            rcon_password: Some(settings.get_rcon_password().into()),
-            steam_api_key: Some(settings.get_steam_api_key().into()),
+            rcon_password: Some(settings.get_rcon_password()),
+            steam_api_key: Some(settings.get_steam_api_key()),
             rcon_port: Some(settings.get_rcon_port()),
         }),
         external: Some(settings.get_external_preferences().clone()),
@@ -267,7 +267,7 @@ async fn put_prefs(State(state): AState, prefs: Json<Preferences>) -> impl IntoR
         if let Some(rcon_port) = internal.rcon_port {
             state
                 .io
-                .send(IOManagerMessage::SetRconPort(rcon_port.clone()))
+                .send(IOManagerMessage::SetRconPort(rcon_port))
                 .unwrap();
             settings.set_rcon_port(rcon_port);
         }


### PR DESCRIPTION
Avoid redundant/repetitive logging in the SteamAPI and RCon modules when the error messages aren't changing

Track error state in RCon module to only warn on first instances of time outs (likely because TF2 isn't launched yet). Don't log the same error message twice, but log different error messages of the same super type.

Remove most of the anyhow errors in command_manager in favour of a strict error type for command manager.

Rework of error messages to make them more intuitive to some users