### PR TITLE
Megascatterbomb/disconnected

### DIFF
--- a/src/io/regexes.rs
+++ b/src/io/regexes.rs
@@ -139,9 +139,9 @@ pub struct StatusLine {
 
 impl StatusLine {
     pub fn parse(caps: Captures) -> Result<StatusLine> {
-        let mut player_state = PlayerState::Spawning;
-        if caps[7].eq("active") {
-            player_state = PlayerState::Active;
+        let mut player_state = PlayerState::Active;
+        if caps[7].eq("spawning") {
+            player_state = PlayerState::Spawning;
         }
 
         Ok(StatusLine {

--- a/src/player.rs
+++ b/src/player.rs
@@ -477,7 +477,7 @@ impl GameInfo {
         self.last_seen = 0;
 
         if self.state == PlayerState::Disconnected {
-            self.state = PlayerState::Spawning;
+            self.state = PlayerState::Active;
         }
     }
 }


### PR DESCRIPTION
Must be merged alongside https://github.com/MegaAntiCheat/MegaAntiCheat-UI/pull/46 to maintain full functionality.

This PR is essentially a manual merge of https://github.com/MegaAntiCheat/client-backend/pull/83 as that was implemented prior to a large refactoring.

Breaking change: Removed the GameInfo.disconnected boolean, instead using GameInfo.state to communicate connection status.

