### PR TITLE
Add date_modified and date_created to PlayerRecord objects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -278,6 +293,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41daef31d7a747c5c847246f36de49ced6f7403b4cdabc807a97b5cc184cda7a"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits 0.2.17",
+ "serde",
+ "wasm-bindgen",
+ "windows-targets 0.52.0",
+]
+
+[[package]]
 name = "clap"
 version = "4.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -330,6 +360,7 @@ dependencies = [
  "anyhow",
  "axum",
  "bitbuffer",
+ "chrono",
  "clap",
  "clap_lex 0.5.1",
  "directories-next",
@@ -906,6 +937,29 @@ dependencies = [
  "native-tls",
  "tokio",
  "tokio-native-tls",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6a67363e2aa4443928ce15e57ebae94fd8949958fd1223c4cfc0cd473ad7539"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -2851,6 +2905,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.0",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,3 +43,4 @@ steamlocate = { version = "1.2.1", features = ["steamid_ng"] }
 watchman_client ={ version = "0.8.0" }
 tf-demo-parser = { git = "https://github.com/MegaAntiCheat/parser" }
 bitbuffer = "0.10.9"
+chrono = { version = "0.4.32", features = ["serde"] }

--- a/src/player_records.rs
+++ b/src/player_records.rs
@@ -8,10 +8,10 @@ use std::{
 };
 
 use anyhow::Context;
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::Map;
 use steamid_ng::SteamID;
-use chrono::{DateTime, Utc};
 
 use crate::{
     args::Args,
@@ -163,10 +163,11 @@ pub struct PlayerRecord {
     pub custom_data: serde_json::Value,
     pub verdict: Verdict,
     pub previous_names: Vec<Arc<str>>,
+    /// Time of last manual change made by the user.
     #[serde(default = "default_date")]
-    pub date_modified: DateTime<Utc>, // updates on any manual change by user.
+    pub modified: DateTime<Utc>,
     #[serde(default = "default_date")]
-    pub date_created: DateTime<Utc>,
+    pub created: DateTime<Utc>,
 }
 
 impl PlayerRecord {

--- a/src/player_records.rs
+++ b/src/player_records.rs
@@ -11,6 +11,7 @@ use anyhow::Context;
 use serde::{Deserialize, Serialize};
 use serde_json::Map;
 use steamid_ng::SteamID;
+use chrono::{DateTime, Utc};
 
 use crate::{
     args::Args,
@@ -156,24 +157,19 @@ impl DerefMut for PlayerRecords {
 // PlayerRecord
 
 /// A Record of a player stored in the persistent personal playerlist
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct PlayerRecord {
     #[serde(default = "default_custom_data")]
     pub custom_data: serde_json::Value,
     pub verdict: Verdict,
-    #[serde(default)]
     pub previous_names: Vec<Arc<str>>,
+    #[serde(default = "default_date")]
+    pub date_modified: DateTime<Utc>, // updates on any manual change by user.
+    #[serde(default = "default_date")]
+    pub date_created: DateTime<Utc>,
 }
 
 impl PlayerRecord {
-    pub fn new() -> PlayerRecord {
-        PlayerRecord {
-            custom_data: serde_json::Value::Object(serde_json::Map::new()),
-            verdict: Verdict::Player,
-            previous_names: Vec::new(),
-        }
-    }
-
     /// Returns true if the record does not hold any meaningful information
     pub fn is_empty(&self) -> bool {
         self.verdict == Verdict::Player && {
@@ -197,14 +193,12 @@ impl PlayerRecord {
     }
 }
 
-impl Default for PlayerRecord {
-    fn default() -> Self {
-        PlayerRecord::new()
-    }
-}
-
 pub fn default_custom_data() -> serde_json::Value {
     serde_json::Value::Object(Map::new())
+}
+
+pub fn default_date() -> DateTime<Utc> {
+    DateTime::<Utc>::from_timestamp(0, 0).unwrap()
 }
 
 /// What a player is marked as in the personal playerlist
@@ -220,5 +214,11 @@ pub enum Verdict {
 impl Display for Verdict {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:?}", self)
+    }
+}
+
+impl Default for Verdict {
+    fn default() -> Self {
+        Self::Player
     }
 }

--- a/src/player_records.rs
+++ b/src/player_records.rs
@@ -198,7 +198,7 @@ pub fn default_custom_data() -> serde_json::Value {
 }
 
 pub fn default_date() -> DateTime<Utc> {
-    DateTime::<Utc>::from_timestamp(0, 0).unwrap()
+    Utc::now()
 }
 
 /// What a player is marked as in the personal playerlist


### PR DESCRIPTION
Title is self explanatory.

I also changed the implementation so PlayerRecord::Default is derived; the fields won't need to all be individually tagged with #[serde(default)] anymore (except for custom defaults). Also implemented a default for Verdict since that was missing.

`date_modified` and `date_created` will be set to the current time for every record that doesn't already have a date to ensure compatibility.