### PR TITLE
Interesting hack using autoref to implement trait specialisation.

### DIFF
--- a/event_loop/src/lib.rs
+++ b/event_loop/src/lib.rs
@@ -166,6 +166,11 @@ impl<M> Handled<M> {
 
 #[allow(unused_variables)]
 pub trait StateUpdater<S>: Sized {
+    fn update_state(self, state: &mut S);
+}
+
+#[allow(unused_variables)]
+impl<M, S> StateUpdater<S> for &M {
     fn update_state(self, state: &mut S) {}
 }
 

--- a/src/command_manager.rs
+++ b/src/command_manager.rs
@@ -5,7 +5,7 @@ use std::{
     time::Duration,
 };
 
-use event_loop::{try_get, Handled, HandlerStruct, Is, StateUpdater};
+use event_loop::{try_get, Handled, HandlerStruct, Is};
 use rcon::Connection;
 use serde::Deserialize;
 use thiserror::Error;
@@ -97,7 +97,6 @@ pub enum Command {
     },
     Custom(Arc<str>),
 }
-impl<S> StateUpdater<S> for Command {}
 
 impl Display for Command {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/src/console.rs
+++ b/src/console.rs
@@ -18,7 +18,6 @@ use crate::{
 
 #[derive(Debug, Clone)]
 pub struct RawConsoleOutput(pub Arc<str>);
-impl<S> StateUpdater<S> for RawConsoleOutput {}
 
 #[allow(clippy::module_name_repetitions)]
 pub struct ConsoleLog {

--- a/src/new_players.rs
+++ b/src/new_players.rs
@@ -1,4 +1,4 @@
-use event_loop::{try_get, Handled, HandlerStruct, Is, StateUpdater};
+use event_loop::{try_get, Handled, HandlerStruct, Is};
 use steamid_ng::SteamID;
 
 use super::console::ConsoleOutput;
@@ -8,7 +8,6 @@ use crate::state::MACState;
 
 #[derive(Debug, Clone)]
 pub struct NewPlayers(pub Vec<SteamID>);
-impl<S> StateUpdater<S> for NewPlayers {}
 
 // Handlers *********************
 

--- a/src/steam_api.rs
+++ b/src/steam_api.rs
@@ -41,7 +41,6 @@ pub enum SteamAPIError {
 
 #[derive(Debug, Clone, Copy)]
 pub struct ProfileLookupBatchTick;
-impl<S> StateUpdater<S> for ProfileLookupBatchTick {}
 
 type ProfileResult = Result<Vec<(SteamID, Result<SteamInfo, SteamAPIError>)>, SteamAPIError>;
 

--- a/src/web.rs
+++ b/src/web.rs
@@ -13,7 +13,7 @@ use axum::{
     routing::{get, post, put},
     Json, Router,
 };
-use event_loop::{try_get, Handled, HandlerStruct, Is, StateUpdater};
+use event_loop::{try_get, Handled, HandlerStruct, Is};
 use futures::Stream;
 use include_dir::Dir;
 use serde::{Deserialize, Serialize};
@@ -54,7 +54,6 @@ pub enum WebRequest {
     /// Tell the client to execute console commands
     PostCommand(RequestedCommands),
 }
-impl StateUpdater<MACState> for WebRequest {}
 
 #[allow(clippy::module_name_repetitions)]
 pub struct WebAPIHandler;


### PR DESCRIPTION
Don't need to add empty impls for messages now.

I learned this from https://github.com/dtolnay/case-studies, which has some really interesting behaviours that can be created with macros.