### PR TITLE
Added css to mimetypes, Fixed invalid javascript mimetype

### DIFF
--- a/src/web.rs
+++ b/src/web.rs
@@ -216,7 +216,7 @@ fn guess_content_type(path: &Path) -> &'static str {
     {
         "htm" | "html" => "text/html",
         "jpg" | "jpeg" => "image/jpeg",
-        "js" => "test/javascript",
+        "js" => "text/javascript",
         "json" => "application/json",
         "png" => "image/png",
         "weba" => "audio/weba",
@@ -227,6 +227,7 @@ fn guess_content_type(path: &Path) -> &'static str {
         "mp4" => "video/mp4",
         "ttf" => "font/ttf",
         "otf" => "font/otf",
+        "css" => "text/css",
         _ => "application/octet-stream",
     }
 }


### PR DESCRIPTION
The javascript mimetype was invalid due to a typo, and I've added css to valid mimetypes (this was a requirement for the vite migration https://github.com/MegaAntiCheat/MegaAntiCheat-UI/pull/52)