### PR TITLE
Persist "Spawning" Flag until player actually spawns.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@
 *.log
 bundle/
 /ui/*
+!/ui/.gitkeep
 /ui_temp


### PR DESCRIPTION
The "Spawning" flag as reported by status typically disappears long before a player has loaded into the game.

I thought it would be useful to "sticky" the spawning flag i.e. persist it until the player actually chooses a class and spawns (or joins spectator).

In addition, I added logic to manually set the PlayerState to Spawning if they've been connected for under 30 seconds and are on the unassigned team. Since the "Spawning" flag reported by status disappears so quickly, it makes sense to set it manually. 