### PR TITLE
Use AtomicWriteFile to prevent possible data corruption

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,6 +116,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-write-file"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8204db279bf648d64fe845bd8840f78b39c8132ed4d6a4194c3b10d4b4cfb0b"
+dependencies = [
+ "nix",
+ "rand",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -293,6 +303,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
 name = "chrono"
 version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -358,6 +374,7 @@ name = "client-backend"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "atomic-write-file",
  "axum",
  "bitbuffer",
  "chrono",
@@ -1206,9 +1223,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.152"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libredox"
@@ -1319,6 +1336,18 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.4.2",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,3 +53,4 @@ event_loop = { version = "0.1.0", path = "event_loop" }
 reqwest = "0.11.24"
 url = "2.5.0"
 tokio-tungstenite = { version = "0.21.0", features = ["native-tls"] }
+atomic-write-file = "0.1.3"


### PR DESCRIPTION
Previously it was not guaranteed to be safe to just quit the app with `Ctrl C` as it might be possible to time it to kill the app while it was attempting to write out the config or playerlist files (resulting in corruption), but there was also no clean way to shutdown the app. 

Such an occurrence of corruption should be extremely unlikely, but probably still possible. A [discord thread](https://discord.com/channels/1112665618869661726/1210138256021393488/1210138256021393488) reported their playerlist and settings files being corrupted. I'm not 100% sure if it was because of the reason mentioned above (as I would have expected at most one of these files to be corrupted), but it's still a good indication we should be more careful about this.

I've just made a small change which uses the [atomic-write-file](https://crates.io/crates/atomic-write-file) crate to guarantee the files are either successfully written out in their entirety or not overwritten at all, so they should never be able to end up in an inconsistent state.