### PR TITLE
History, Post User, Additional stuff

### DIFF
--- a/src/console.rs
+++ b/src/console.rs
@@ -1,4 +1,4 @@
-use std::{path::PathBuf, sync::Arc};
+use std::path::PathBuf;
 
 use event_loop::{Handled, HandlerStruct, Is, MessageSource, StateUpdater};
 use regex::Regex;
@@ -18,11 +18,11 @@ use crate::{
 };
 
 #[derive(Debug, Clone)]
-pub struct RawConsoleOutput(pub Arc<str>);
+pub struct RawConsoleOutput(pub String);
 
 #[allow(clippy::module_name_repetitions)]
 pub struct ConsoleLog {
-    pub recv: UnboundedReceiver<Arc<str>>,
+    pub recv: UnboundedReceiver<String>,
     logged_error: bool,
 }
 impl<M: Is<RawConsoleOutput>> MessageSource<M> for ConsoleLog {

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -328,8 +328,8 @@ impl DemoManager {
         header: &Header,
         demo_name: &str,
     ) -> Option<event_loop::Handled<M>> {
-        let host = settings.masterbase_host();
-        let key = settings.masterbase_key();
+        let host = settings.masterbase_host().to_owned();
+        let key = settings.masterbase_key().to_owned();
         let map = header.map.clone();
         let fake_ip = header.server.clone();
         let http = settings.use_masterbase_http();
@@ -399,12 +399,12 @@ impl DemoManager {
         settings: &Settings,
         late_bytes: Vec<u8>,
     ) -> Option<event_loop::Handled<M>> {
-        let host = settings.masterbase_host();
-        let key = settings.masterbase_key();
+        let host = settings.masterbase_host().to_owned();
+        let key = settings.masterbase_key().to_owned();
         let http = settings.use_masterbase_http();
 
         Handled::future(async move {
-            let send_result = send_late_bytes(host.clone(), key.clone(), http, late_bytes).await;
+            let send_result = send_late_bytes(&host, &key, http, late_bytes).await;
 
             match send_result {
                 Ok(send_response) => {
@@ -729,7 +729,7 @@ where
                 let name = steamid
                     .as_ref()
                     .and_then(|&id| state.players.get_name(id))
-                    .unwrap_or_else(|| "Someone".into());
+                    .unwrap_or("Someone");
 
                 let vote: &str = self
                     .votes

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, path::PathBuf, sync::Arc, time::Duration};
+use std::{collections::HashMap, path::PathBuf, time::Duration};
 
 use event_loop::StateUpdater;
 use serde::{Deserialize, Serialize};
@@ -28,7 +28,7 @@ pub struct UserUpdates(pub HashMap<SteamID, UserUpdate>);
 impl StateUpdater<MACState> for UserUpdates {
     fn update_state(self, state: &mut MACState) {
         for (k, v) in self.0 {
-            let name = state.players.get_name(k);
+            let name = state.players.get_name(k).map(ToOwned::to_owned);
 
             // Insert record if it didn't exist
             let record = state.players.records.entry(k).or_default();
@@ -40,7 +40,7 @@ impl StateUpdater<MACState> for UserUpdates {
             if let Some(verdict) = v.local_verdict {
                 record.set_verdict(verdict);
                 if let Some(name) = name {
-                    record.add_previous_name(name);
+                    record.add_previous_name(&name);
                 }
             }
 
@@ -81,11 +81,11 @@ pub async fn emit_on_timer<M: 'static + Send>(
 #[serde(rename_all = "camelCase")]
 pub struct InternalPreferences {
     pub friends_api_usage: Option<FriendsAPIUsage>,
-    pub tf2_directory: Option<Arc<str>>,
-    pub rcon_password: Option<Arc<str>>,
-    pub steam_api_key: Option<Arc<str>>,
-    pub masterbase_key: Option<Arc<str>>,
-    pub masterbase_host: Option<Arc<str>>,
+    pub tf2_directory: Option<String>,
+    pub rcon_password: Option<String>,
+    pub steam_api_key: Option<String>,
+    pub masterbase_key: Option<String>,
+    pub masterbase_host: Option<String>,
     pub rcon_port: Option<u16>,
 }
 
@@ -99,7 +99,7 @@ impl StateUpdater<MACState> for Preferences {
     fn update_state(self, state: &mut MACState) {
         if let Some(internal) = self.internal {
             if let Some(tf2_dir) = internal.tf2_directory {
-                let path: PathBuf = tf2_dir.to_string().into();
+                let path: PathBuf = tf2_dir.into();
                 state.settings.set_tf2_directory(path);
             }
             if let Some(rcon_pwd) = internal.rcon_password {

--- a/src/events.rs
+++ b/src/events.rs
@@ -87,6 +87,7 @@ pub struct InternalPreferences {
     pub masterbase_key: Option<String>,
     pub masterbase_host: Option<String>,
     pub rcon_port: Option<u16>,
+    pub dumb_autokick: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -119,6 +120,9 @@ impl StateUpdater<MACState> for Preferences {
             }
             if let Some(masterbase_host) = internal.masterbase_host {
                 state.settings.set_masterbase_host(masterbase_host);
+            }
+            if let Some(autokick) = internal.dumb_autokick {
+                state.settings.set_autokick_bots(autokick);
             }
         }
 

--- a/src/io/filewatcher.rs
+++ b/src/io/filewatcher.rs
@@ -1,4 +1,4 @@
-use std::{path::PathBuf, sync::Arc, time::Duration};
+use std::{path::PathBuf, time::Duration};
 
 use anyhow::{anyhow, Context, Result};
 use clap_lex::SeekFrom;
@@ -20,12 +20,12 @@ pub struct FileWatcher {
     file_path: PathBuf,
     /// The file currently being watched
     open_file: Option<OpenFile>,
-    response_send: UnboundedSender<Arc<str>>,
+    response_send: UnboundedSender<String>,
 }
 
 impl FileWatcher {
     #[must_use]
-    pub fn new(path: PathBuf) -> (UnboundedReceiver<Arc<str>>, Self) {
+    pub fn new(path: PathBuf) -> (UnboundedReceiver<String>, Self) {
         let (resp_tx, resp_rx) = unbounded_channel();
 
         let file_watcher = Self {

--- a/src/io/g15.rs
+++ b/src/io/g15.rs
@@ -2,8 +2,6 @@
 #![allow(unused_variables)]
 #![allow(clippy::missing_errors_doc)]
 
-use std::sync::Arc;
-
 use anyhow::Result;
 use regex::{Captures, Regex};
 use steamid_ng::SteamID;
@@ -187,7 +185,7 @@ pub fn parse_userid(caps: &Captures, players: &mut [G15Player]) -> Result<()> {
 #[derive(Debug, Clone)]
 #[allow(clippy::module_name_repetitions)]
 pub struct G15Player {
-    pub name: Option<Arc<str>>,   // eg "Lilith"
+    pub name: Option<String>,     // eg "Lilith"
     pub ping: Option<u32>,        // eg 21
     pub score: Option<u32>,       // eg 16
     pub deaths: Option<u32>,      // eg 5
@@ -198,7 +196,7 @@ pub struct G15Player {
     pub connected: Option<bool>,  // eg true
     pub valid: Option<bool>,      // eg true
     pub alive: Option<bool>,      // eg true
-    pub userid: Option<Arc<str>>, // eg "301"
+    pub userid: Option<String>,   // eg "301"
 }
 impl G15Player {
     const fn new() -> Self {

--- a/src/io/regexes.rs
+++ b/src/io/regexes.rs
@@ -1,8 +1,6 @@
 #![allow(non_upper_case_globals)]
 #![allow(unused_variables)]
 
-use std::sync::Arc;
-
 use anyhow::{Context, Ok, Result};
 use regex::Captures;
 use steamid_ng::SteamID;
@@ -21,7 +19,7 @@ use crate::player::PlayerState;
 
 pub const REGEX_HOSTNAME: &str = r"^hostname: (.*)$";
 #[derive(Debug, Clone)]
-pub struct Hostname(pub Arc<str>);
+pub struct Hostname(pub String);
 impl Hostname {
     #[must_use]
     pub fn parse(caps: &Captures) -> Self {
@@ -31,7 +29,7 @@ impl Hostname {
 
 pub const REGEX_IP: &str = r"^udp/ip  : (.*)$";
 #[derive(Debug, Clone)]
-pub struct ServerIP(pub Arc<str>);
+pub struct ServerIP(pub String);
 impl ServerIP {
     #[must_use]
     pub fn parse(caps: &Captures) -> Self {
@@ -41,7 +39,7 @@ impl ServerIP {
 
 pub const REGEX_MAP: &str = r"^map     : (.+) at: .*$";
 #[derive(Debug, Clone)]
-pub struct Map(pub Arc<str>);
+pub struct Map(pub String);
 impl Map {
     #[must_use]
     pub fn parse(caps: &Captures) -> Self {
@@ -79,11 +77,11 @@ impl PlayerCount {
 pub const REGEX_KILL: &str = r"^(.*)\skilled\s(.*)\swith\s(.*)\.(\s\(crit\))?$";
 #[derive(Debug, Clone)]
 pub struct PlayerKill {
-    pub killer_name: Arc<str>,
-    pub killer_steamid: Option<Arc<str>>,
-    pub victim_name: Arc<str>,
-    pub victim_steamid: Option<Arc<str>>,
-    pub weapon: Arc<str>,
+    pub killer_name: String,
+    pub killer_steamid: Option<String>,
+    pub victim_name: String,
+    pub victim_steamid: Option<String>,
+    pub weapon: String,
     pub crit: bool,
 }
 
@@ -109,9 +107,9 @@ pub const REGEX_CHAT: &str = r"^(?:\*DEAD\*)?(?:\(TEAM\))?\s?(.*)\s:\s\s(.*)$";
 
 #[derive(Debug, Clone)]
 pub struct ChatMessage {
-    pub player_name: Arc<str>,
-    pub steamid: Option<Arc<str>>,
-    pub message: Arc<str>,
+    pub player_name: String,
+    pub steamid: Option<String>,
+    pub message: String,
 }
 
 impl ChatMessage {
@@ -134,8 +132,8 @@ pub const REGEX_STATUS: &str =
 
 #[derive(Debug, Clone)]
 pub struct StatusLine {
-    pub userid: Arc<str>,
-    pub name: Arc<str>,
+    pub userid: String,
+    pub name: String,
     pub steamid: SteamID,
     pub time: u32,
     pub ping: u32,

--- a/src/main.rs
+++ b/src/main.rs
@@ -199,7 +199,7 @@ fn main() {
                 .add_handler(LookupProfiles::new())
                 .add_handler(LookupFriends::new())
                 .add_handler(DumbAutoKick)
-                .add_handler(WebAPIHandler);
+                .add_handler(WebAPIHandler::new());
 
             if args.print_votes {
                 event_loop = event_loop.add_handler(PrintVotes::new());

--- a/src/player.rs
+++ b/src/player.rs
@@ -18,7 +18,7 @@ pub mod tags {
     pub const FRIEND: &str = "Friend";
 }
 
-const MAX_HISTORY_LEN: usize = 100;
+// const MAX_HISTORY_LEN: usize = 100;
 
 pub struct Players {
     pub game_info: HashMap<SteamID, GameInfo>,
@@ -45,7 +45,7 @@ impl Players {
             records,
 
             connected: Vec::new(),
-            history: VecDeque::with_capacity(MAX_HISTORY_LEN),
+            history: VecDeque::new(),
             user,
         }
     }
@@ -224,10 +224,10 @@ impl Players {
             .retain(|p| !unaccounted_players.iter().any(|up| up == p));
 
         // Shrink to not go past max number of players
-        let num_players = self.history.len() + unaccounted_players.len();
-        for _ in MAX_HISTORY_LEN..num_players {
-            self.history.pop_front();
-        }
+        // let num_players = self.history.len() + unaccounted_players.len();
+        // for _ in MAX_HISTORY_LEN..num_players {
+        //     self.history.pop_front();
+        // }
 
         for p in unaccounted_players {
             self.history.push_back(p);

--- a/src/player.rs
+++ b/src/player.rs
@@ -340,6 +340,12 @@ impl Players {
             return Some(gi.name.clone());
         } else if let Some(si) = self.steam_info.get(&steamid) {
             return Some(si.account_name.clone());
+        } else if let Some(last_name) = self
+            .records
+            .get(&steamid)
+            .map(|r| r.previous_names().get(0))
+        {
+            return last_name.cloned();
         }
 
         None
@@ -573,6 +579,13 @@ pub struct Friend {
 pub struct FriendInfo {
     pub public: Option<bool>,
     friends: Vec<Friend>,
+}
+
+impl FriendInfo {
+    #[must_use]
+    pub fn friends(&self) -> &[Friend] {
+        &self.friends
+    }
 }
 
 impl Deref for FriendInfo {

--- a/src/player.rs
+++ b/src/player.rs
@@ -292,6 +292,10 @@ impl Players {
                 continue;
             };
 
+            if let Some(r) = self.records.get_mut(&steamid) {
+                r.mark_seen();
+            }
+
             // Add to connected players if they aren't already
             if !self.connected.contains(&steamid) {
                 self.connected.push(steamid);
@@ -313,6 +317,10 @@ impl Players {
 
     pub fn handle_status_line(&mut self, status: StatusLine) {
         let steamid = status.steamid;
+
+        if let Some(r) = self.records.get_mut(&steamid) {
+            r.mark_seen();
+        }
 
         // Add to connected players if they aren't already
         if !self.connected.contains(&steamid) {

--- a/src/player.rs
+++ b/src/player.rs
@@ -587,7 +587,10 @@ impl DerefMut for FriendInfo {
 // Useful
 
 #[allow(clippy::trivially_copy_pass_by_ref)]
-fn serialize_steamid_as_string<S: Serializer>(steamid: &SteamID, s: S) -> Result<S::Ok, S::Error> {
+pub fn serialize_steamid_as_string<S: Serializer>(
+    steamid: &SteamID,
+    s: S,
+) -> Result<S::Ok, S::Error> {
     format!("{}", u64::from(*steamid)).serialize(s)
 }
 

--- a/src/player.rs
+++ b/src/player.rs
@@ -3,6 +3,7 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
+use chrono::{DateTime, Utc};
 use serde::{Serialize, Serializer};
 use steamid_ng::SteamID;
 
@@ -418,6 +419,7 @@ pub struct SteamInfo {
     pub vac_bans: i64,
     pub game_bans: i64,
     pub days_since_last_ban: Option<i64>,
+    pub fetched: DateTime<Utc>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]

--- a/src/player_records.rs
+++ b/src/player_records.rs
@@ -143,6 +143,7 @@ impl PlayerRecords {
 
     pub fn update_name(&mut self, steamid: SteamID, name: Arc<str>) {
         if let Some(record) = self.records.get_mut(&steamid) {
+            record.name = name.clone();
             if !record.previous_names.contains(&name) {
                 record.add_previous_name(name);
             }

--- a/src/player_records.rs
+++ b/src/player_records.rs
@@ -183,6 +183,7 @@ impl DerefMut for PlayerRecords {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(default)]
 pub struct PlayerRecord {
+    pub name: Arc<str>,
     custom_data: serde_json::Value,
     verdict: Verdict,
     previous_names: Vec<Arc<str>>,
@@ -207,6 +208,7 @@ impl PlayerRecord {
 impl Default for PlayerRecord {
     fn default() -> Self {
         Self {
+            name: default_name(),
             custom_data: default_custom_data(),
             verdict: Verdict::default(),
             previous_names: Vec::new(),
@@ -270,6 +272,11 @@ pub fn default_custom_data() -> serde_json::Value {
 #[must_use]
 pub fn default_date() -> DateTime<Utc> {
     Utc::now()
+}
+
+#[must_use]
+pub fn default_name() -> Arc<str> {
+    Arc::from("")
 }
 
 /// What a player is marked as in the personal playerlist

--- a/src/player_records.rs
+++ b/src/player_records.rs
@@ -188,6 +188,7 @@ pub struct PlayerRecord {
     custom_data: serde_json::Value,
     verdict: Verdict,
     previous_names: Vec<String>,
+    last_seen: Option<DateTime<Utc>>,
     /// Time of last manual change made by the user.
     modified: DateTime<Utc>,
     created: DateTime<Utc>,
@@ -213,6 +214,7 @@ impl Default for PlayerRecord {
             custom_data: default_custom_data(),
             verdict: Verdict::default(),
             previous_names: Vec::new(),
+            last_seen: None,
             modified: default_date(),
             created: default_date(),
         }
@@ -262,6 +264,15 @@ impl PlayerRecord {
     #[must_use]
     pub const fn created(&self) -> DateTime<Utc> {
         self.created
+    }
+
+    #[must_use]
+    pub const fn last_seen(&self) -> Option<DateTime<Utc>> {
+        self.last_seen
+    }
+
+    pub fn mark_seen(&mut self) {
+        self.last_seen = Some(Utc::now());
     }
 }
 

--- a/src/player_records.rs
+++ b/src/player_records.rs
@@ -142,10 +142,6 @@ impl PlayerRecords {
 
     pub fn update_name(&mut self, steamid: SteamID, name: &str) {
         if let Some(record) = self.records.get_mut(&steamid) {
-            if record.name == name {
-                return;
-            }
-            record.name = name.to_owned();
             record.add_previous_name(name);
         }
     }
@@ -184,7 +180,6 @@ impl DerefMut for PlayerRecords {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(default)]
 pub struct PlayerRecord {
-    pub name: String,
     custom_data: serde_json::Value,
     verdict: Verdict,
     previous_names: Vec<String>,
@@ -210,7 +205,6 @@ impl PlayerRecord {
 impl Default for PlayerRecord {
     fn default() -> Self {
         Self {
-            name: String::default(),
             custom_data: default_custom_data(),
             verdict: Verdict::default(),
             previous_names: Vec::new(),
@@ -250,11 +244,12 @@ impl PlayerRecord {
         &self.previous_names
     }
     pub fn add_previous_name(&mut self, name: &str) -> &mut Self {
-        if self.previous_names.iter().any(|pn| pn == name) {
+        if self.previous_names.first().is_some_and(|n| n == name) {
             return self;
-        };
+        }
 
-        self.previous_names.push(name.to_owned());
+        self.previous_names.retain(|n| n != name);
+        self.previous_names.insert(0, name.to_owned());
         self
     }
     #[must_use]

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use serde::Serialize;
 
 use crate::{
@@ -10,9 +8,9 @@ use crate::{
 // Server
 
 pub struct Server {
-    map: Option<Arc<str>>,
-    ip: Option<Arc<str>>,
-    hostname: Option<Arc<str>>,
+    map: Option<String>,
+    ip: Option<String>,
+    hostname: Option<String>,
     max_players: Option<u32>,
     num_players: Option<u32>,
     gamemode: Option<Gamemode>,
@@ -22,7 +20,7 @@ pub struct Server {
 pub struct Gamemode {
     pub matchmaking: bool,
     #[serde(rename = "type")]
-    pub game_type: Arc<str>,
+    pub game_type: String,
     pub vanilla: bool,
 }
 
@@ -44,18 +42,18 @@ impl Server {
     // **** Getters / Setters ****
 
     #[must_use]
-    pub fn map(&self) -> Option<Arc<str>> {
-        self.map.clone()
+    pub fn map(&self) -> Option<&str> {
+        self.map.as_deref()
     }
 
     #[must_use]
-    pub fn ip(&self) -> Option<Arc<str>> {
-        self.ip.clone()
+    pub fn ip(&self) -> Option<&str> {
+        self.ip.as_deref()
     }
 
     #[must_use]
-    pub fn hostname(&self) -> Option<Arc<str>> {
-        self.hostname.clone()
+    pub fn hostname(&self) -> Option<&str> {
+        self.hostname.as_deref()
     }
 
     #[must_use]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,4 +1,5 @@
 use std::{
+    fmt::Display,
     io::{self, ErrorKind, Write},
     path::{Path, PathBuf},
 };
@@ -32,6 +33,12 @@ pub enum FriendsAPIUsage {
     None,
     CheatersOnly,
     All,
+}
+
+impl Display for FriendsAPIUsage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{self:?}")
+    }
 }
 
 impl FriendsAPIUsage {
@@ -481,6 +488,9 @@ impl Settings {
     #[must_use]
     pub const fn autokick_bots(&self) -> bool {
         self.autokick_bots
+    }
+    pub fn set_autokick_bots(&mut self, kick: bool) {
+        self.autokick_bots = kick;
     }
 
     /// Attempts to find (and create) a directory to be used for configuration

--- a/src/steam_api.rs
+++ b/src/steam_api.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, VecDeque};
 
+use chrono::Utc;
 use event_loop::{try_get, Handled, HandlerStruct, Is, StateUpdater};
 use steamid_ng::SteamID;
 use tappet::{
@@ -451,6 +452,7 @@ pub async fn request_steam_info(
                     } else {
                         None
                     },
+                    fetched: Utc::now(),
                 };
                 Ok(steam_info)
             };

--- a/src/steam_api.rs
+++ b/src/steam_api.rs
@@ -126,6 +126,7 @@ where
                     masterbase_key: _,
                     masterbase_host: _,
                     rcon_port: _,
+                    dumb_autokick: _,
                 }),
             external: _,
         }) = try_get(message)

--- a/src/steam_api.rs
+++ b/src/steam_api.rs
@@ -57,6 +57,9 @@ impl StateUpdater<MACState> for ProfileLookupResult {
         for (steamid, result) in results {
             match result {
                 Ok(steaminfo) => {
+                    if let Some(r) = state.players.records.get_mut(steamid) {
+                        r.add_previous_name(&steaminfo.account_name);
+                    }
                     state.players.steam_info.insert(*steamid, steaminfo.clone());
                 }
                 Err(e) => {

--- a/src/web.rs
+++ b/src/web.rs
@@ -404,21 +404,21 @@ fn get_game_response(state: &MACState) -> String {
     #[derive(Serialize)]
     #[allow(non_snake_case)]
     struct Game<'a> {
-        map: &'a Option<Arc<str>>,
-        ip: &'a Option<Arc<str>>,
-        hostname: &'a Option<Arc<str>>,
-        maxPlayers: &'a Option<u32>,
-        numPlayers: &'a Option<u32>,
+        map: Option<&'a str>,
+        ip: Option<&'a str>,
+        hostname: Option<&'a str>,
+        maxPlayers: Option<u32>,
+        numPlayers: Option<u32>,
         gamemode: Option<&'a Gamemode>,
         players: &'a Players,
     }
 
     let game = Game {
-        map: &state.server.map(),
-        ip: &state.server.ip(),
-        hostname: &state.server.hostname(),
-        maxPlayers: &state.server.max_players(),
-        numPlayers: &state.server.num_players(),
+        map: state.server.map(),
+        ip: state.server.ip(),
+        hostname: state.server.hostname(),
+        maxPlayers: state.server.max_players(),
+        numPlayers: state.server.num_players(),
         gamemode: state.server.gamemode(),
         players: &state.players,
     };
@@ -481,10 +481,10 @@ fn get_prefs_response(state: &MACState) -> String {
         internal: Some(InternalPreferences {
             friends_api_usage: Some(settings.friends_api_usage()),
             tf2_directory: Some(settings.tf2_directory().to_string_lossy().into()),
-            rcon_password: Some(settings.rcon_password()),
-            steam_api_key: Some(settings.steam_api_key()),
-            masterbase_key: Some(settings.masterbase_key()),
-            masterbase_host: Some(settings.masterbase_host()),
+            rcon_password: Some(settings.rcon_password().to_owned()),
+            steam_api_key: Some(settings.steam_api_key().to_owned()),
+            masterbase_key: Some(settings.masterbase_key().to_owned()),
+            masterbase_host: Some(settings.masterbase_host().to_owned()),
             rcon_port: Some(settings.rcon_port()),
         }),
         external: Some(settings.external_preferences().clone()),
@@ -563,15 +563,15 @@ async fn get_playerlist(State(state): State<WebState>) -> impl IntoResponse {
 #[allow(non_snake_case)]
 #[derive(Debug, Serialize)]
 struct PlayerRecordResponse<'a> {
-    name: Arc<str>,
+    name: String,
     isSelf: bool,
     #[serde(serialize_with = "serialize_steamid_as_string")]
     steamID64: SteamID,
     convicted: Option<bool>,
-    localVerdict: Option<Arc<str>>,
+    localVerdict: Option<String>,
     steamInfo: Option<&'a SteamInfo>,
     customData: &'a serde_json::Value,
-    previousNames: Option<&'a [Arc<str>]>,
+    previousNames: Option<&'a [String]>,
     friends: Option<&'a [Friend]>,
     friendsIsPublic: Option<bool>,
 }
@@ -589,7 +589,7 @@ fn get_playerlist_response(state: &MACState) -> String {
                 isSelf: state.settings.steam_user().is_some_and(|user| user == *id),
                 steamID64: *id,
                 convicted: Some(false),
-                localVerdict: Some(Arc::from(record.verdict().to_string())),
+                localVerdict: Some(record.verdict().to_string()),
                 steamInfo: state.players.steam_info.get(id),
                 customData: record.custom_data(),
                 previousNames: Some(record.previous_names()),

--- a/src/web.rs
+++ b/src/web.rs
@@ -238,6 +238,11 @@ impl WebAPIHandler {
                     .map(|(id, si)| {
                         let mut player = state.players.get_serializable_player(*id);
                         player.steamInfo = si.as_ref();
+
+                        if let Some(si) = si {
+                            player.name = &si.account_name;
+                        }
+
                         player
                     })
                     .collect();

--- a/src/web.rs
+++ b/src/web.rs
@@ -13,6 +13,7 @@ use axum::{
     routing::{get, post, put},
     Json, Router,
 };
+use chrono::{DateTime, Utc};
 use event_loop::{try_get, Handled, HandlerStruct, Is};
 use futures::Stream;
 use include_dir::Dir;
@@ -574,6 +575,8 @@ struct PlayerRecordResponse<'a> {
     previousNames: Option<&'a [String]>,
     friends: Option<&'a [Friend]>,
     friendsIsPublic: Option<bool>,
+    modified: DateTime<Utc>,
+    created: DateTime<Utc>,
 }
 
 fn get_playerlist_response(state: &MACState) -> String {
@@ -595,6 +598,8 @@ fn get_playerlist_response(state: &MACState) -> String {
                 previousNames: Some(record.previous_names()),
                 friends: friends.map(FriendInfo::friends),
                 friendsIsPublic: friends.and_then(|f| f.public),
+                modified: record.modified(),
+                created: record.created(),
             }
         })
         .collect();

--- a/src/web.rs
+++ b/src/web.rs
@@ -25,6 +25,7 @@ use super::command_manager::Command;
 use crate::{
     events::{InternalPreferences, Preferences, UserUpdate, UserUpdates},
     player::{Player, Players},
+    player_records::PlayerRecord,
     server::Gamemode,
     state::MACState,
 };
@@ -409,8 +410,10 @@ async fn get_playerlist(State(state): State<WebState>) -> impl IntoResponse {
     )
 }
 
-fn get_playerlist_response(_state: &MACState) -> String {
-    "Not yet implemented".into()
+fn get_playerlist_response(state: &MACState) -> String {
+    let records: Vec<&PlayerRecord> = state.players.records.records.values().collect();
+
+    serde_json::to_string(&records).expect("Epic serialization fail")
 }
 
 // Commands

--- a/src/web.rs
+++ b/src/web.rs
@@ -487,6 +487,7 @@ fn get_prefs_response(state: &MACState) -> String {
             masterbase_key: Some(settings.masterbase_key().to_owned()),
             masterbase_host: Some(settings.masterbase_host().to_owned()),
             rcon_port: Some(settings.rcon_port()),
+            dumb_autokick: Some(settings.autokick_bots()),
         }),
         external: Some(settings.external_preferences().clone()),
     };

--- a/src/web.rs
+++ b/src/web.rs
@@ -564,7 +564,7 @@ async fn get_playerlist(State(state): State<WebState>) -> impl IntoResponse {
 #[allow(non_snake_case)]
 #[derive(Debug, Serialize)]
 struct PlayerRecordResponse<'a> {
-    name: String,
+    name: &'a str,
     isSelf: bool,
     #[serde(serialize_with = "serialize_steamid_as_string")]
     steamID64: SteamID,
@@ -588,7 +588,7 @@ fn get_playerlist_response(state: &MACState) -> String {
             let friends = state.players.friend_info.get(id);
 
             PlayerRecordResponse {
-                name: record.name.clone(),
+                name: record.previous_names().first().map_or("", String::as_str),
                 isSelf: state.settings.steam_user().is_some_and(|user| user == *id),
                 steamID64: *id,
                 convicted: Some(false),

--- a/src/web.rs
+++ b/src/web.rs
@@ -588,7 +588,7 @@ fn get_playerlist_response(state: &MACState) -> String {
             let friends = state.players.friend_info.get(id);
 
             PlayerRecordResponse {
-                name: record.previous_names().first().map_or("", String::as_str),
+                name: state.players.get_name(*id).unwrap_or(""),
                 isSelf: state.settings.steam_user().is_some_and(|user| user == *id),
                 steamID64: *id,
                 convicted: Some(false),


### PR DESCRIPTION
Lots of small and some large changes:
- `playerlist` endpoint to show whatever info is currently present on all the players recorded
- Fixes to name updates, and record account name from steam api
- `user` POST endpoint to lookup and request information about specific accounts
- Update `modified` and `created` fields in records
- Add `fetched` field to Steam info
- Add `dumbAutokick` field to internal preferences field of preferences API endpoint
- Internal code improvements