### PR TITLE
Cache steam info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,6 +388,7 @@ dependencies = [
  "keyvalues-serde 0.1.0",
  "notify",
  "open",
+ "pot",
  "rcon",
  "regex",
  "reqwest",
@@ -471,6 +472,12 @@ name = "crossbeam-utils"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-common"
@@ -885,6 +892,16 @@ dependencies = [
  "tokio",
  "tokio-util 0.7.10",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+dependencies = [
+ "cfg-if",
+ "crunchy",
 ]
 
 [[package]]
@@ -1735,6 +1752,17 @@ name = "pkg-config"
 version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
+
+[[package]]
+name = "pot"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df842bdb3b0553a411589e64aaa1a7d0c0259f72fabcedfaa841683ae3019d80"
+dependencies = [
+ "byteorder",
+ "half",
+ "serde",
+]
 
 [[package]]
 name = "powerfmt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,3 +58,4 @@ reqwest = "0.11.24"
 url = "2.5.0"
 tokio-tungstenite = { version = "0.21.0", features = ["native-tls"] }
 atomic-write-file = "0.1.3"
+pot = "3.0.0"

--- a/src/command_manager.rs
+++ b/src/command_manager.rs
@@ -12,7 +12,12 @@ use thiserror::Error;
 use tokio::{net::TcpStream, sync::Mutex, time::timeout};
 
 use super::console::RawConsoleOutput;
-use crate::{events::Refresh, player_records::Verdict, state::MACState, player::{PlayerState, Team}};
+use crate::{
+    events::Refresh,
+    player::{PlayerState, Team},
+    player_records::Verdict,
+    state::MACState,
+};
 
 #[derive(Debug, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -350,7 +355,11 @@ where
                     .is_some_and(|r| r.verdict() == Verdict::Bot)
             })
             .filter_map(|s| state.players.game_info.get(s))
-            .filter(|gi| gi.team == user_team && gi.team != Team::Unassigned && gi.state == PlayerState::Active)
+            .filter(|gi| {
+                gi.team == user_team
+                    && gi.team != Team::Unassigned
+                    && gi.state == PlayerState::Active
+            })
             .map(|gi| gi.userid.clone())
             .map(|id| Command::Kick {
                 player: id,

--- a/src/main.rs
+++ b/src/main.rs
@@ -230,6 +230,7 @@ fn main() {
                     tracing::info!("Saving and exiting.");
                     state.players.records.save_ok();
                     state.settings.save_ok();
+                    state.players.save_steam_info_ok();
                     std::process::exit(0);
                 }
 

--- a/src/player.rs
+++ b/src/player.rs
@@ -1,10 +1,11 @@
 use std::{
     collections::{HashMap, HashSet, VecDeque},
     ops::{Deref, DerefMut},
+    path::{Path, PathBuf},
 };
 
 use chrono::{DateTime, Utc};
-use serde::{Serialize, Serializer};
+use serde::{Deserialize, Serialize, Serializer};
 use steamid_ng::SteamID;
 
 use crate::{
@@ -13,6 +14,7 @@ use crate::{
         regexes::StatusLine,
     },
     player_records::{default_custom_data, PlayerRecords, Verdict},
+    settings::{ConfigFilesError, Settings},
 };
 
 pub mod tags {
@@ -38,7 +40,7 @@ pub struct Players {
 impl Players {
     #[must_use]
     pub fn new(records: PlayerRecords, user: Option<SteamID>) -> Self {
-        Self {
+        let mut players = Self {
             game_info: HashMap::new(),
             steam_info: HashMap::new(),
             friend_info: HashMap::new(),
@@ -48,7 +50,20 @@ impl Players {
             connected: Vec::new(),
             history: VecDeque::new(),
             user,
+        };
+
+        match players.load_steam_info() {
+            Ok(()) => tracing::info!(
+                "Loaded steam info cache with {} entries.",
+                players.steam_info.len()
+            ),
+            Err(ConfigFilesError::IO(_, e)) if e.kind() == std::io::ErrorKind::NotFound => {
+                tracing::warn!("No steam info cache was found, creating a new one.");
+            }
+            Err(e) => tracing::error!("Failed to load steam info cache: {e}"),
         }
+
+        players
     }
 
     /// Check if a player has a particular tag set
@@ -358,6 +373,51 @@ impl Players {
 
         None
     }
+
+    fn locate_steam_info_cache_path() -> Result<PathBuf, ConfigFilesError> {
+        Settings::locate_config_directory().map(|p| p.join("steam_cache.bin"))
+    }
+
+    /// # Errors
+    /// If the file could not be read from disk or the data could not be deserialized
+    pub fn load_steam_info(&mut self) -> Result<(), ConfigFilesError> {
+        let path = Self::locate_steam_info_cache_path()?;
+        self.load_steam_info_from(&path)
+    }
+
+    /// # Errors
+    /// If the data could not be serialized or the file could not be written back to disk
+    pub fn save_steam_info(&self) -> Result<(), ConfigFilesError> {
+        let path = Self::locate_steam_info_cache_path()?;
+        self.save_steam_info_to(&path)
+    }
+
+    pub fn save_steam_info_ok(&self) {
+        if let Err(e) = self.save_steam_info() {
+            tracing::error!("Failed to save steam info cache: {e}");
+        } else {
+            tracing::debug!("Saved steam info cache.");
+        }
+    }
+
+    fn load_steam_info_from(&mut self, path: &Path) -> Result<(), ConfigFilesError> {
+        let contents = std::fs::read(path)
+            .map_err(|e| ConfigFilesError::IO(path.to_string_lossy().into(), e))?;
+        let steam_info = pot::from_slice(&contents)
+            .map_err(|e| ConfigFilesError::Pot(path.to_string_lossy().into(), e))?;
+
+        self.steam_info = steam_info;
+        Ok(())
+    }
+
+    fn save_steam_info_to(&self, path: &Path) -> Result<(), ConfigFilesError> {
+        let contents = pot::to_vec(&self.steam_info)
+            .map_err(|e| ConfigFilesError::Pot(path.to_string_lossy().into(), e))?;
+        std::fs::write(path, contents)
+            .map_err(|e| ConfigFilesError::IO(path.to_string_lossy().into(), e))?;
+
+        Ok(())
+    }
 }
 
 impl Serialize for Players {
@@ -412,7 +472,7 @@ impl Serialize for Team {
     }
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SteamInfo {
     #[serde(rename = "name")]
@@ -430,7 +490,7 @@ pub struct SteamInfo {
     pub fetched: DateTime<Utc>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ProfileVisibility {
     Private = 1,
     FriendsOnly = 2,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -25,6 +25,8 @@ pub enum ConfigFilesError {
     Yaml(String, serde_yaml::Error),
     #[error("Failed to parse json file {0}, {1:?}")]
     Json(String, serde_json::Error),
+    #[error("Pot error with file {0}, {1:?}")]
+    Pot(String, pot::Error),
     #[error("{0:?}")]
     Other(#[from] anyhow::Error),
 }


### PR DESCRIPTION
When exiting the client, all the steam info in memory is dumped into a binary file cache, when starting the client the cache is read back so that some accounts can have some steam info present without having to retrieve it again each time.

(Depends on #140)