### PR TITLE
Further CI improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust
-        run: rustup install stable
+        # This makes rustup install the toolchain from `rust-toolchain.toml`.
+        # I couldn't find a better way to do this.
+        # There doesn't appear to be a command specifically to install from the toolchain file.
+        # Running any cargo command does the same thing, but I feel this is more elegant.
+        run: rustup show
       - name: Check Formatting
         run: cargo fmt --check
       - name: Lint
@@ -49,7 +53,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust
-        run: rustup install stable
+        run: rustup show
       - name: Build
         run: cargo build --verbose --release
       - name: Test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/lib.rs"
 unsafe_code = "forbid"
 
 [lints.clippy]
-pedantic = "warn"
+pedantic = { level = "warn", priority = -1 }
 unwrap_used = "warn"
 
 [profile.release-with-debug]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.78.0"
+profile = "default"

--- a/src/command_manager.rs
+++ b/src/command_manager.rs
@@ -78,11 +78,11 @@ impl PartialEq for Error {
 /// Current(CommandManagerError)
 #[derive(PartialEq)]
 enum ErrorState {
-    /// Never had an error, never been connected to RCon
+    /// Never had an error, never been connected to `RCon`
     Never,
-    /// Currently connected to RCon, logged no error state
+    /// Currently connected to `RCon`, logged no error state
     Okay,
-    /// No longer or never was connected to RCon due to the wrapped error
+    /// No longer or never was connected to `RCon` due to the wrapped error
     Current(Error),
 }
 
@@ -96,8 +96,8 @@ pub enum Command {
     Say(String),
     SayTeam(String),
     Kick {
-        /// The uid of the player as returned by [Command::Status] or
-        /// [Command::G15]
+        /// The uid of the player as returned by [`Command::Status`] or
+        /// [`Command::G15`]
         player: String,
         #[serde(default)]
         reason: KickReason,

--- a/src/io/g15.rs
+++ b/src/io/g15.rs
@@ -11,7 +11,7 @@ use crate::player::Team;
 
 #[derive(Debug, Error, Clone)]
 pub enum Error {
-    /// Occurs when m_someArray\[X\] has some X greater than 33 (since these are
+    /// Occurs when `m_someArray`\[X\] has some X greater than 33 (since these are
     /// static 34 element arrays)
     #[error("index provided from output of g15 command was invalid")]
     IndexOutOfBounds,

--- a/src/masterbase.rs
+++ b/src/masterbase.rs
@@ -97,9 +97,9 @@ pub async fn new_demo_session(
 ) -> Result<DemoSession, Error> {
     let params: [(&str, &str); 4] = [
         ("api_key", &key),
-        ("fake_ip", &fake_ip),
-        ("map", &map),
-        ("demo_name", &demo_name),
+        ("fake_ip", fake_ip),
+        ("map", map),
+        ("demo_name", demo_name),
     ];
 
     // Request to start session

--- a/src/steam_api.rs
+++ b/src/steam_api.rs
@@ -99,6 +99,12 @@ pub struct LookupProfiles {
     in_progress: Vec<SteamID>,
 }
 
+impl Default for LookupProfiles {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl LookupProfiles {
     #[must_use]
     pub const fn new() -> Self {


### PR DESCRIPTION
- Use `rust-toolchain.toml` to set a fixed version of Rust, so builds don't just start failing when new Clippy lints are added

Thank you to Lilith for ~~complaining on Discord~~ reminding me of the necessity of this.

I chose to set the version at `1.78.0` because they have already fixed the Clippy lints for it on their branch, so it wouldn't make sense to downgrade.