### PR TITLE
Resolve SteamIDs of Chat and Kill messages + some event loop changes

### DIFF
--- a/event_loop/src/lib.rs
+++ b/event_loop/src/lib.rs
@@ -1,9 +1,9 @@
 //! An Event Loop abstraction that can be easily composed of message and handler
 //! types, then run over some state.
 //!
-//! Messages can be any type (implementing [`StateUpdater<S>`] will allow the
+//! Messages can be any type (implementing [`Message<S>`] will allow the
 //! message type to update the state once it has been appropriately handled),
-//! and can be handled by any type implementing [`HandlerStruct<S, IM, OM>`].
+//! and can be handled by any type implementing [`MessageHandler<S, IM, OM>`].
 //! Message sources are of the form `Box<dyn MessageSource<M>>` and are generaly
 //! something like a receiving channel for the message type, or one of the types
 //! that make it up.
@@ -17,24 +17,24 @@
 //! ```
 //! use std::sync::mpsc::{channel, Receiver, Sender};
 //!
-//! use event_loop::{define_events, try_get, EventLoop, HandlerStruct, Is, StateUpdater};
+//! use event_loop::{define_events, try_get, EventLoop, MessageHandler, Is, Message};
 //!
 //! struct State {
 //!     count: u32,
 //! }
 //!
 //! struct Refresh;
-//! impl StateUpdater<State> for Refresh {
+//! impl Message<State> for Refresh {
 //!     fn update_state(self, state: &mut State) { state.count = 0; }
 //! }
 //!
 //! struct Increment;
-//! impl StateUpdater<State> for Increment {
+//! impl Message<State> for Increment {
 //!     fn update_state(self, state: &mut State) { state.count += 1; }
 //! }
 //!
 //! struct Alert;
-//! impl<IM, OM> HandlerStruct<State, IM, OM> for Alert
+//! impl<IM, OM> MessageHandler<State, IM, OM> for Alert
 //! where
 //!     IM: Is<Increment> + Is<Refresh>,
 //! {
@@ -104,8 +104,8 @@ use tokio::{sync::mpsc::UnboundedReceiver, task::JoinHandle};
 pub struct EventLoop<S, M, H>
 where
     S: Send,
-    M: Send + StateUpdater<S> + 'static,
-    H: HandlerStruct<S, M, M>,
+    M: Send + Message<S> + 'static,
+    H: MessageHandler<S, M, M>,
 {
     pub sources: Vec<Box<dyn MessageSource<M> + 'static + Send>>,
     pub handlers: Vec<H>,
@@ -118,8 +118,8 @@ where
 impl<S, M, H> EventLoop<S, M, H>
 where
     S: Send,
-    M: Send + StateUpdater<S> + 'static,
-    H: HandlerStruct<S, M, M>,
+    M: Send + Message<S> + 'static,
+    H: MessageHandler<S, M, M>,
 {
     #[must_use]
     pub fn new() -> Self {
@@ -144,8 +144,10 @@ where
         self
     }
 
-    pub fn handle_message(&mut self, message: M, state: &mut S) -> Vec<Action<M>> {
+    pub fn handle_message(&mut self, mut message: M, state: &mut S) -> Vec<Action<M>> {
         let mut out = Vec::new();
+
+        message.preprocess(state);
 
         for h in &mut self.handlers {
             match h.handle_message(state, &message) {
@@ -217,11 +219,11 @@ where
     }
 }
 
-pub trait HandlerStruct<S, IM, OM> {
+pub trait MessageHandler<S, IM, OM> {
     fn handle_message(&mut self, state: &S, message: &IM) -> Option<Handled<OM>>;
 }
 
-impl<S, IM, OM, T> HandlerStruct<S, IM, OM> for &T {
+impl<S, IM, OM, T> MessageHandler<S, IM, OM> for &T {
     fn handle_message(&mut self, _state: &S, _message: &IM) -> Option<Handled<OM>> {
         None
     }
@@ -230,8 +232,8 @@ impl<S, IM, OM, T> HandlerStruct<S, IM, OM> for &T {
 impl<S, M, H> Default for EventLoop<S, M, H>
 where
     S: Send,
-    M: Send + StateUpdater<S> + 'static,
-    H: HandlerStruct<S, M, M>,
+    M: Send + Message<S> + 'static,
+    H: MessageHandler<S, M, M>,
 {
     fn default() -> Self {
         Self::new()
@@ -286,14 +288,19 @@ impl<M> Handled<M> {
 }
 
 #[allow(unused_variables)]
-pub trait StateUpdater<S>: Sized {
-    fn update_state(self, state: &mut S);
-}
-
-#[allow(unused_variables)]
-impl<M, S> StateUpdater<S> for &M {
+pub trait Message<S>: Sized {
+    fn preprocess(&mut self, state: &S) {}
     fn update_state(self, state: &mut S) {}
 }
+
+// #[allow(unused_variables)]
+// impl<M, S> Message<S> for &M {}
+
+// #[allow(unused_variables)]
+// impl<M, S> Message<S> for M {
+//     fn preprocess(&mut self, state: &S) {}
+//     fn update_state(self, state: &mut S) {}
+// }
 
 pub trait MessageSource<M> {
     fn next_message(&mut self) -> Option<M>;
@@ -343,10 +350,18 @@ macro_rules! define_events {
         }
 
         // Impl update_state
-        impl event_loop::StateUpdater<$state> for $message_enum {
+        impl event_loop::Message<$state> for $message_enum {
+            fn preprocess(&mut self, state: &$state) {
+                use $message_enum::*;
+                use event_loop::Message as MessageTrait;
+                match self {
+                    $message_enum::None => {},
+                    $($message(i) => i.preprocess(state)),+
+                }
+            }
             fn update_state(self, state: &mut $state) {
                 use $message_enum::*;
-                use event_loop::StateUpdater;
+                use event_loop::Message as MessageTrait;
                 match self {
                     $message_enum::None => {},
                     $($message(i) => i.update_state(state)),+
@@ -401,8 +416,8 @@ macro_rules! define_events {
             $($handler($handler)),+
         }
 
-        // Impl HandlerStruct<State, Message>
-        impl event_loop::HandlerStruct<$state, $message_enum, $message_enum> for $handler_enum {
+        // Impl MessageHandler<State, Message>
+        impl event_loop::MessageHandler<$state, $message_enum, $message_enum> for $handler_enum {
             fn handle_message(&mut self, state: &$state, message: &$message_enum) -> Option<event_loop::Handled<$message_enum>> {
                 match self {
                     $($handler_enum::$handler(inner) => inner.handle_message(state, message)),+

--- a/src/command_manager.rs
+++ b/src/command_manager.rs
@@ -5,7 +5,7 @@ use std::{
     time::Duration,
 };
 
-use event_loop::{try_get, Handled, HandlerStruct, Is};
+use event_loop::{try_get, Handled, Is, MessageHandler};
 use rcon::Connection;
 use serde::Deserialize;
 use thiserror::Error;
@@ -104,6 +104,7 @@ pub enum Command {
     },
     Custom(String),
 }
+impl<S> event_loop::Message<S> for Command {}
 
 impl Display for Command {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -299,7 +300,7 @@ impl Default for CommandManager {
     }
 }
 
-impl<IM, OM> HandlerStruct<MACState, IM, OM> for CommandManager
+impl<IM, OM> MessageHandler<MACState, IM, OM> for CommandManager
 where
     IM: Is<Command> + Is<Refresh>,
     OM: Is<RawConsoleOutput>,
@@ -325,7 +326,7 @@ where
 }
 
 pub struct DumbAutoKick;
-impl<IM, OM> HandlerStruct<MACState, IM, OM> for DumbAutoKick
+impl<IM, OM> MessageHandler<MACState, IM, OM> for DumbAutoKick
 where
     IM: Is<Refresh>,
     OM: Is<Command>,

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -1,5 +1,5 @@
 use bitbuffer::{BitError, BitRead, BitReadBuffer, BitReadStream, LittleEndian};
-use event_loop::{try_get, Handled, HandlerStruct, Is, MessageSource};
+use event_loop::{try_get, Handled, Is, MessageHandler, MessageSource};
 use notify::{event::ModifyKind, Config, Event, RecommendedWatcher, RecursiveMode, Watcher};
 use std::{
     collections::HashMap,
@@ -41,6 +41,7 @@ pub struct DemoMessage {
     pub tick: u32,
     pub event: DemoEvent,
 }
+impl<S> event_loop::Message<S> for DemoMessage {}
 
 #[allow(clippy::module_name_repetitions)]
 #[derive(Debug, Clone)]
@@ -64,6 +65,7 @@ pub struct DemoBytes {
     pub id: usize,
     pub bytes: Vec<u8>,
 }
+impl<S> event_loop::Message<S> for DemoBytes {}
 
 #[allow(clippy::module_name_repetitions)]
 pub struct DemoWatcher {
@@ -589,7 +591,7 @@ impl Default for DemoManager {
     }
 }
 
-impl<IM, OM> HandlerStruct<MACState, IM, OM> for DemoManager
+impl<IM, OM> MessageHandler<MACState, IM, OM> for DemoManager
 where
     IM: Is<DemoBytes> + Is<NewPlayers> + Is<UserUpdates>,
     OM: Is<DemoMessage>,
@@ -837,7 +839,7 @@ impl Default for PrintVotes {
     }
 }
 
-impl<IM, OM> HandlerStruct<MACState, IM, OM> for PrintVotes
+impl<IM, OM> MessageHandler<MACState, IM, OM> for PrintVotes
 where
     IM: Is<DemoMessage>,
 {

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, path::PathBuf, time::Duration};
 
-use event_loop::StateUpdater;
+use event_loop::Message;
 use serde::{Deserialize, Serialize};
 use steamid_ng::SteamID;
 use tokio::sync::mpsc::Receiver;
@@ -9,10 +9,13 @@ use crate::{player_records::Verdict, settings::FriendsAPIUsage, state::MACState}
 
 #[derive(Debug, Clone, Copy)]
 pub struct Refresh;
-impl StateUpdater<MACState> for Refresh {
+impl Message<MACState> for Refresh {
     fn update_state(self, state: &mut MACState) {
         state.players.refresh();
     }
+
+    #[allow(unused_variables)]
+    fn preprocess(&mut self, state: &MACState) {}
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -25,7 +28,7 @@ pub struct UserUpdate {
 
 #[derive(Debug, Clone)]
 pub struct UserUpdates(pub HashMap<SteamID, UserUpdate>);
-impl StateUpdater<MACState> for UserUpdates {
+impl Message<MACState> for UserUpdates {
     fn update_state(self, state: &mut MACState) {
         for (k, v) in self.0 {
             let name = state.players.get_name(k).map(ToOwned::to_owned);
@@ -96,7 +99,7 @@ pub struct Preferences {
     pub external: Option<serde_json::Value>,
 }
 
-impl StateUpdater<MACState> for Preferences {
+impl Message<MACState> for Preferences {
     fn update_state(self, state: &mut MACState) {
         if let Some(internal) = self.internal {
             if let Some(tf2_dir) = internal.tf2_directory {

--- a/src/io/regexes.rs
+++ b/src/io/regexes.rs
@@ -6,7 +6,7 @@ use regex::Captures;
 use serde::{Deserialize, Serialize};
 use steamid_ng::SteamID;
 
-use crate::player::PlayerState;
+use crate::player::{serialize_maybe_steamid_as_string, PlayerState};
 
 /*
     Useful commands:
@@ -79,8 +79,10 @@ pub const REGEX_KILL: &str = r"^(.*)\skilled\s(.*)\swith\s(.*)\.(\s\(crit\))?$";
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct PlayerKill {
     pub killer_name: String,
+    #[serde(serialize_with = "serialize_maybe_steamid_as_string")]
     pub killer_steamid: Option<SteamID>,
     pub victim_name: String,
+    #[serde(serialize_with = "serialize_maybe_steamid_as_string")]
     pub victim_steamid: Option<SteamID>,
     pub weapon: String,
     pub crit: bool,
@@ -109,6 +111,7 @@ pub const REGEX_CHAT: &str = r"^(?:\*DEAD\*)?(?:\(TEAM\))?\s?(.*)\s:\s\s(.*)$";
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ChatMessage {
     pub player_name: String,
+    #[serde(serialize_with = "serialize_maybe_steamid_as_string")]
     pub steamid: Option<SteamID>,
     pub message: String,
 }

--- a/src/io/regexes.rs
+++ b/src/io/regexes.rs
@@ -79,9 +79,9 @@ pub const REGEX_KILL: &str = r"^(.*)\skilled\s(.*)\swith\s(.*)\.(\s\(crit\))?$";
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct PlayerKill {
     pub killer_name: String,
-    pub killer_steamid: Option<String>,
+    pub killer_steamid: Option<SteamID>,
     pub victim_name: String,
-    pub victim_steamid: Option<String>,
+    pub victim_steamid: Option<SteamID>,
     pub weapon: String,
     pub crit: bool,
 }
@@ -98,14 +98,6 @@ impl PlayerKill {
             crit: caps.get(4).is_some(),
         }
     }
-
-    pub fn set_steam_id_killer(&mut self, id: SteamID) {
-        self.killer_steamid = Some(format!("{}", u64::from(id)));
-    }
-
-    pub fn set_steam_id_victim(&mut self, id: SteamID) {
-        self.victim_steamid = Some(format!("{}", u64::from(id)));
-    }
 }
 
 /// Chat message
@@ -117,7 +109,7 @@ pub const REGEX_CHAT: &str = r"^(?:\*DEAD\*)?(?:\(TEAM\))?\s?(.*)\s:\s\s(.*)$";
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ChatMessage {
     pub player_name: String,
-    pub steamid: Option<String>,
+    pub steamid: Option<SteamID>,
     pub message: String,
 }
 
@@ -129,10 +121,6 @@ impl ChatMessage {
             steamid: None,
             message: caps[2].into(),
         }
-    }
-
-    pub fn set_steam_id(&mut self, id: SteamID) {
-        self.steamid = Some(format!("{}", u64::from(id)));
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -206,14 +206,10 @@ fn main() {
                 PathBuf::from(state.settings.tf2_directory()).join("tf/console.log");
             let console_log = Box::new(ConsoleLog::new(log_file_path).await);
 
-            let lookup_batch_timer =
-                emit_on_timer(Duration::from_millis(500), || ProfileLookupBatchTick).await;
-            let refresh_timer = emit_on_timer(Duration::from_secs(3), || Refresh).await;
-
             let mut event_loop: EventLoop<MACState, Message, Handler> = EventLoop::new()
                 .add_source(console_log)
-                .add_source(refresh_timer)
-                .add_source(lookup_batch_timer)
+                .add_source(emit_on_timer(Duration::from_secs(3), || Refresh).await)
+                .add_source(emit_on_timer(Duration::from_millis(500), || ProfileLookupBatchTick).await)
                 .add_source(Box::new(web_requests))
                 .add_handler(DemoManager::new())
                 .add_handler(CommandManager::new())

--- a/src/new_players.rs
+++ b/src/new_players.rs
@@ -1,4 +1,4 @@
-use event_loop::{try_get, Handled, HandlerStruct, Is};
+use event_loop::{try_get, Handled, Is, MessageHandler};
 use steamid_ng::SteamID;
 
 use super::console::ConsoleOutput;
@@ -8,12 +8,13 @@ use crate::state::MACState;
 
 #[derive(Debug, Clone)]
 pub struct NewPlayers(pub Vec<SteamID>);
+impl<S> event_loop::Message<S> for NewPlayers {}
 
 // Handlers *********************
 
 #[allow(clippy::module_name_repetitions)]
 pub struct ExtractNewPlayers;
-impl<IM, OM> HandlerStruct<MACState, IM, OM> for ExtractNewPlayers
+impl<IM, OM> MessageHandler<MACState, IM, OM> for ExtractNewPlayers
 where
     IM: Is<ConsoleOutput>,
     OM: Is<NewPlayers>,

--- a/src/player.rs
+++ b/src/player.rs
@@ -697,6 +697,17 @@ pub fn serialize_steamid_as_string<S: Serializer>(
     format!("{}", u64::from(*steamid)).serialize(s)
 }
 
+#[allow(clippy::trivially_copy_pass_by_ref, clippy::missing_errors_doc)]
+pub fn serialize_maybe_steamid_as_string<S: Serializer>(
+    steamid: &Option<SteamID>,
+    s: S,
+) -> Result<S::Ok, S::Error> {
+    match steamid {
+        Some(steamid) => format!("{}", u64::from(*steamid)).serialize(s),
+        None => s.serialize_none(),
+    }
+}
+
 #[allow(non_snake_case)]
 #[derive(Debug, Serialize)]
 pub struct Player<'a> {

--- a/src/player.rs
+++ b/src/player.rs
@@ -375,6 +375,14 @@ impl Players {
     }
 
     #[must_use]
+    pub fn get_steamid_from_name(&self, name: &str) -> Option<SteamID> {
+        self.connected
+            .iter()
+            .find(|&s| self.game_info.get(s).is_some_and(|gi| gi.name == name))
+            .copied()
+    }
+
+    #[must_use]
     pub fn get_name_to_steam_ids_map(&self) -> HashMap<String, SteamID> {
         self.connected
             .iter()

--- a/src/sse_events.rs
+++ b/src/sse_events.rs
@@ -74,7 +74,7 @@ pub struct VoteCastEventWrapped {
 
 impl VoteCastEventWrapped {
     #[must_use]
-    pub fn from_vote_cast_event(event: VoteCastEvent, voter: Option<SteamID>) -> Self {
+    pub const fn from_vote_cast_event(event: VoteCastEvent, voter: Option<SteamID>) -> Self {
         Self {
             voter,
             voter_name: None,


### PR DESCRIPTION
- Renamed some event loop types (`StateUpdater` -> `Message`, `HandlerStruct` -> `MessageHandler`)
- Removed default implementation of `Message`, now all types that are used as messages must implement it explicitly (couldn't find a nice way to work around this :c )
- Added a preprocessing step to messages, allowing them to initialise themselves using the current state before being handled
- Chat and Kill messages now resolve the user/victim/killer SteamIDs in preprocessing