### PR TITLE
Properly check for empty custom data

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -106,7 +106,7 @@ fn main() {
     let settings = Settings::load_or_create(&args);
     settings.save_ok();
 
-    let playerlist = PlayerRecords::load_or_create(&args);
+    let mut playerlist = PlayerRecords::load_or_create(&args);
     playerlist.save_ok();
 
     let players = Players::new(playerlist, settings.steam_user());

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -635,7 +635,12 @@ pub fn merge_json_objects(a: &mut Value, b: Value) {
     if let Value::Object(a) = a {
         if let Value::Object(b) = b {
             for (k, v) in b {
-                if v.is_null() {
+                // Remove if null or empty
+                if v.is_null()
+                    || v.as_str().is_some_and(str::is_empty)
+                    || v.as_array().is_some_and(Vec::is_empty)
+                    || v.as_object().is_some_and(Map::is_empty)
+                {
                     a.remove(&k);
                 } else {
                     merge_json_objects(a.entry(k).or_insert(Value::Null), v);


### PR DESCRIPTION
Previously custom_data was considered empty if it was null or an empty string, array or object, however not if the object was a map which contained an empty string. This would result in some player records not being pruned if they had previously had any notes or an alias set, despite not currently storing any useful information because they contained multiple empty strings.

Custom data that looks like this:
```json
"custom_data" : { 
    "alias" : "",
    "playerNote" : ""
}
```
Would not be pruned, whereas with these changes it does.