### PR TITLE
Add Chat history and Killfeed

### DIFF
--- a/src/io/regexes.rs
+++ b/src/io/regexes.rs
@@ -2,6 +2,7 @@
 #![allow(unused_variables)]
 
 use anyhow::{Context, Ok, Result};
+use chrono::{DateTime, Utc};
 use regex::Captures;
 use serde::{Deserialize, Serialize};
 use steamid_ng::SteamID;
@@ -86,6 +87,7 @@ pub struct PlayerKill {
     pub victim_steamid: Option<SteamID>,
     pub weapon: String,
     pub crit: bool,
+    pub timestamp: DateTime<Utc>,
 }
 
 impl PlayerKill {
@@ -98,6 +100,7 @@ impl PlayerKill {
             victim_steamid: None,
             weapon: caps[3].into(),
             crit: caps.get(4).is_some(),
+            timestamp: Utc::now(),
         }
     }
 }
@@ -114,6 +117,7 @@ pub struct ChatMessage {
     #[serde(serialize_with = "serialize_maybe_steamid_as_string")]
     pub steamid: Option<SteamID>,
     pub message: String,
+    pub timestamp: DateTime<Utc>,
 }
 
 impl ChatMessage {
@@ -123,6 +127,7 @@ impl ChatMessage {
             player_name: caps[1].into(),
             steamid: None,
             message: caps[2].into(),
+            timestamp: Utc::now(),
         }
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -14,6 +14,8 @@ pub struct Server {
     max_players: Option<u32>,
     num_players: Option<u32>,
     gamemode: Option<Gamemode>,
+    chat_history: Vec<ChatMessage>,
+    kill_history: Vec<PlayerKill>,
 }
 
 #[derive(Debug, Serialize, Clone)]
@@ -36,6 +38,9 @@ impl Server {
             num_players: None,
 
             gamemode: None,
+
+            chat_history: Vec::new(),
+            kill_history: Vec::new(),
         }
     }
 
@@ -69,6 +74,16 @@ impl Server {
     #[must_use]
     pub const fn gamemode(&self) -> Option<&Gamemode> {
         self.gamemode.as_ref()
+    }
+
+    #[must_use]
+    pub fn chat_history(&self) -> &[ChatMessage] {
+        &self.chat_history
+    }
+
+    #[must_use]
+    pub fn kill_history(&self) -> &[PlayerKill] {
+        &self.kill_history
     }
 }
 
@@ -112,14 +127,14 @@ impl Server {
     #[allow(clippy::unused_self)]
     #[allow(clippy::needless_pass_by_value)]
     fn handle_chat(&mut self, chat: ChatMessage) {
-        // TODO
         tracing::debug!("Chat: {:?}", chat);
+        self.chat_history.push(chat);
     }
 
     #[allow(clippy::unused_self)]
     #[allow(clippy::needless_pass_by_value)]
     fn handle_kill(&mut self, kill: PlayerKill) {
-        // TODO
         tracing::debug!("Kill: {:?}", kill);
+        self.kill_history.push(kill);
     }
 }


### PR DESCRIPTION
- Add chat history and killfeed fields to the `Server` object, which will be updated as they happen
- Add a timestamp (in Utc) to `ChatMessage` and `PlayerKill` structs
- Add API endpoints for fetching chat and kill history (documentation pending, idk just query it and see what you get)