### PR TITLE
Minor steam profile lookup additions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,8 @@ use events::{Preferences, Refresh, UserUpdates};
 use new_players::{ExtractNewPlayers, NewPlayers};
 use sse_events::SseEventBroadcaster;
 use steam_api::{
-    FriendLookupResult, LookupFriends, LookupProfiles, ProfileLookupBatchTick, ProfileLookupResult,
+    FriendLookupResult, LookupFriends, LookupProfiles, ProfileLookupBatchTick,
+    ProfileLookupRequest, ProfileLookupResult,
 };
 use web::{WebAPIHandler, WebRequest};
 
@@ -71,6 +72,7 @@ define_events!(
         ProfileLookupBatchTick,
         ProfileLookupResult,
         FriendLookupResult,
+        ProfileLookupRequest,
 
         Preferences,
         UserUpdates,

--- a/src/player.rs
+++ b/src/player.rs
@@ -514,6 +514,13 @@ pub struct SteamInfo {
     pub fetched: DateTime<Utc>,
 }
 
+impl SteamInfo {
+    #[must_use]
+    pub fn expired(&self) -> bool {
+        Utc::now().signed_duration_since(self.fetched).num_hours() > 3
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ProfileVisibility {
     Private = 1,

--- a/src/player.rs
+++ b/src/player.rs
@@ -1,6 +1,5 @@
 use std::{
     collections::{HashMap, HashSet, VecDeque},
-    fmt::Display,
     ops::{Deref, DerefMut},
     path::{Path, PathBuf},
 };

--- a/src/player.rs
+++ b/src/player.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{HashMap, HashSet, VecDeque},
+    fmt::Display,
     ops::{Deref, DerefMut},
     path::{Path, PathBuf},
 };

--- a/src/steam_api.rs
+++ b/src/steam_api.rs
@@ -185,7 +185,7 @@ where
                     .players
                     .steam_info
                     .get(s)
-                    .is_some_and(|si| Utc::now().signed_duration_since(si.fetched).num_hours() < 3)
+                    .is_some_and(|si| !si.expired())
             });
             if self.batch_buffer.is_empty() {
                 return Handled::none();

--- a/src/web.rs
+++ b/src/web.rs
@@ -170,7 +170,12 @@ impl WebAPIHandler {
             .iter()
             .filter(|&s| {
                 !self.profile_requests_in_progress.contains(s)
-                    || !state.players.steam_info.contains_key(s)
+                    // Filter for no steam info or expired steam info
+                    || state
+                        .players
+                        .steam_info
+                        .get(s)
+                        .map_or(true, SteamInfo::expired)
             })
             .copied()
             .collect();


### PR DESCRIPTION
- Add `ProfileLookupRequest` message for delegating profile lookups to another handler
- Fix minor bug
- Add `SteamInfo::expired`