### PR TITLE
Create ui directory if it doesn't exist

### DIFF
--- a/include_ui.sh
+++ b/include_ui.sh
@@ -89,6 +89,7 @@ if [ "$UPDATE_FLAG" -eq 0 ]; then
 
     npm exec pnpm i
     npm exec pnpm run build
+    mkdir -p ../ui/
     cp dist/* ../ui/
 
     echo "Removing temp files"


### PR DESCRIPTION
Currently, the bash script fails if no "ui" directory exists, forcing the user to create it themselves.