### PR TITLE
Friend / Party detection

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod io;
 pub mod launchoptions;
 pub mod masterbase;
 pub mod new_players;
+pub mod parties;
 pub mod player;
 pub mod player_records;
 pub mod server;

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,7 @@ mod io;
 mod launchoptions;
 mod masterbase;
 mod new_players;
+mod parties;
 mod player;
 mod player_records;
 mod server;

--- a/src/parties.rs
+++ b/src/parties.rs
@@ -1,0 +1,188 @@
+use std::collections::{HashMap, HashSet};
+
+use crate::player::FriendInfo;
+use steamid_ng::SteamID;
+
+pub struct Parties {
+    parties: Vec<HashSet<SteamID>>,
+}
+
+impl Parties {
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            parties: Vec::new(),
+        }
+    }
+
+    #[must_use]
+    pub fn parties(&self) -> &[HashSet<SteamID>] {
+        &self.parties
+    }
+
+    pub fn find_parties(&mut self, friends: &HashMap<SteamID, FriendInfo>, connected: &[SteamID]) {
+        let are_friends = |a: SteamID, b: SteamID| {
+            friends
+                .get(&a)
+                .is_some_and(|fi| fi.friends().iter().any(|f| f.steamid == b))
+        };
+
+        let mut parties: Vec<HashSet<_>> = Vec::new();
+
+        // Iterate (connected) players
+        for (&s, fi) in friends.iter().filter(|(s, _)| connected.contains(s)) {
+            // Iterate parties, seeing if there's any parties the player is friends with all members
+            // If yes, create a copy of that party with itself added
+            let new_parties: Vec<_> = parties
+                .iter()
+                .filter(|&p| p.iter().all(|&s2| are_friends(s, s2)))
+                .map(|p| {
+                    let mut p = p.clone();
+                    p.insert(s);
+                    p
+                })
+                .collect();
+
+            parties.extend(new_parties);
+
+            // Iterate (connected) friends
+            // Create a new party for each pair of friends
+            let new_parties: Vec<_> = fi
+                .friends()
+                .iter()
+                .map(|f| f.steamid)
+                .filter(|s2| connected.contains(s2))
+                // .filter(|&s2| parties.iter().all(|p| !(p.contains(&s) || p.contains(&s2))))
+                .map(|s2| {
+                    let mut new_party = HashSet::new();
+                    new_party.insert(s);
+                    new_party.insert(s2);
+                    new_party
+                })
+                .collect();
+
+            parties.extend(new_parties);
+        }
+
+        // Finalise parties
+        self.parties.clear();
+
+        // Iterate parties
+        'outer: for new_p in parties {
+            let mut to_remove = Vec::new();
+
+            for (i, other_p) in self.parties.iter().enumerate() {
+                // If the party is a subset of one of the parties in the final list, skip it
+                if new_p.is_subset(other_p) {
+                    continue 'outer;
+                }
+
+                // If the party is a superset of one of the parties in the final list, replace it
+                if new_p.is_superset(other_p) {
+                    to_remove.push(i);
+                }
+            }
+
+            // Remove other sets (in reverse order to not screw up indexing)
+            to_remove.into_iter().rev().for_each(|i| {
+                self.parties.remove(i);
+            });
+
+            // Otherwise add it
+            self.parties.push(new_p);
+        }
+    }
+}
+
+impl Default for Parties {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    #![allow(clippy::unreadable_literal)]
+
+    use std::collections::{HashMap, HashSet};
+
+    use crate::player::{Friend, FriendInfo};
+    use steamid_ng::SteamID;
+
+    use super::Parties;
+
+    #[test]
+    pub fn party_generation() {
+        let s: Vec<_> = [0, 1, 2, 3, 4, 5, 6]
+            .iter()
+            .map(|&s| SteamID::from(s))
+            .collect();
+
+        let friends: HashMap<SteamID, Vec<SteamID>> = HashMap::from([
+            (s[1], vec![s[2], s[3], s[4], s[5]]),
+            (s[2], vec![s[1], s[4], s[6]]),
+            (s[3], vec![s[1], s[5], s[6]]),
+            (s[4], vec![s[1], s[2], s[5]]),
+            (s[5], vec![s[1], s[3], s[4]]),
+            (s[6], vec![s[2], s[3]]),
+        ]);
+
+        let friends: HashMap<SteamID, FriendInfo> = friends
+            .into_iter()
+            .map(|(s, fi)| {
+                (
+                    s,
+                    FriendInfo {
+                        public: None,
+                        friends: fi
+                            .into_iter()
+                            .map(|s| Friend {
+                                steamid: s,
+                                friend_since: 0,
+                            })
+                            .collect(),
+                    },
+                )
+            })
+            .collect();
+
+        let mut parties = Parties::new();
+        parties.find_parties(&friends, &s);
+
+        println!("All parties:");
+        for p in parties.parties() {
+            print!("\t");
+            for s in p {
+                print!("{}, ", u64::from(*s));
+            }
+            println!();
+        }
+        println!();
+        println!();
+
+        let expected_parties: &[&[SteamID]] = &[
+            &[s[1], s[2], s[4]],
+            &[s[1], s[3], s[5]],
+            &[s[1], s[4], s[5]],
+            &[s[2], s[6]],
+            &[s[3], s[6]],
+        ];
+
+        let expected_parties: Vec<HashSet<SteamID>> = expected_parties
+            .iter()
+            .map(|&l| l.iter().copied().collect::<HashSet<_>>())
+            .collect();
+
+        for p in &expected_parties {
+            print!("Party: ");
+            for s in p {
+                print!("{}, ", u64::from(*s));
+            }
+            println!();
+
+            assert!(parties.parties.contains(p));
+        }
+
+        assert!(parties.parties().len() == expected_parties.len());
+    }
+}

--- a/src/player.rs
+++ b/src/player.rs
@@ -13,6 +13,7 @@ use crate::{
         g15::{self, G15Player},
         regexes::StatusLine,
     },
+    parties::Parties,
     player_records::{default_custom_data, PlayerRecord, PlayerRecords, Verdict},
     settings::{ConfigFilesError, Settings},
 };
@@ -29,11 +30,14 @@ pub struct Players {
     pub friend_info: HashMap<SteamID, FriendInfo>,
     pub records: PlayerRecords,
     pub tags: HashMap<SteamID, HashSet<String>>,
+    pub parties: Parties,
 
     pub connected: Vec<SteamID>,
     pub history: VecDeque<SteamID>,
 
     pub user: Option<SteamID>,
+
+    parties_needs_update: bool,
 }
 
 #[allow(dead_code)]
@@ -46,10 +50,13 @@ impl Players {
             friend_info: HashMap::new(),
             tags: HashMap::new(),
             records,
+            parties: Parties::new(),
 
             connected: Vec::new(),
             history: VecDeque::new(),
             user,
+
+            parties_needs_update: false,
         };
 
         match players.load_steam_info() {
@@ -119,6 +126,8 @@ impl Players {
     /// Sets the friends list and friends list visibility, returning any old
     /// friends that have been removed
     fn set_friends(&mut self, steamid: SteamID, friends: Vec<Friend>) -> Vec<SteamID> {
+        self.parties_needs_update = true;
+
         let friend_info = self.friend_info.entry(steamid).or_default();
 
         friend_info.public = Some(true);
@@ -241,6 +250,10 @@ impl Players {
             .copied()
             .collect();
 
+        if !unaccounted_players.is_empty() {
+            self.parties_needs_update = true;
+        }
+
         self.connected.retain(|s| !unaccounted_players.contains(s));
 
         // Remove any of them from the history as they will be added more recently
@@ -260,6 +273,12 @@ impl Players {
         // Mark all remaining players as unaccounted, they will be marked as accounted
         // again when they show up in status or another console command.
         self.game_info.values_mut().for_each(GameInfo::next_cycle);
+
+        if self.parties_needs_update {
+            self.parties
+                .find_parties(&self.friend_info, &self.connected);
+            self.parties_needs_update = false;
+        }
     }
 
     /// Gets a struct containing all the relevant data on a player in a
@@ -322,6 +341,7 @@ impl Players {
             // Add to connected players if they aren't already
             if !self.connected.contains(&steamid) {
                 self.connected.push(steamid);
+                self.parties_needs_update = true;
             }
 
             // Update game info
@@ -348,6 +368,7 @@ impl Players {
         // Add to connected players if they aren't already
         if !self.connected.contains(&steamid) {
             self.connected.push(steamid);
+            self.parties_needs_update = true;
         }
 
         if let Some(game_info) = self.game_info.get_mut(&steamid) {
@@ -678,7 +699,7 @@ pub struct Friend {
 #[derive(Debug, Serialize, Default)]
 pub struct FriendInfo {
     pub public: Option<bool>,
-    friends: Vec<Friend>,
+    pub friends: Vec<Friend>,
 }
 
 impl FriendInfo {

--- a/src/player.rs
+++ b/src/player.rs
@@ -666,7 +666,7 @@ impl GameInfo {
     }
 
     pub(crate) fn next_cycle(&mut self) {
-        const DISCONNECTED_THRESHOLD: u32 = 1;
+        const DISCONNECTED_THRESHOLD: u32 = 2;
 
         self.last_seen += 1;
         if self.last_seen > DISCONNECTED_THRESHOLD {
@@ -675,7 +675,7 @@ impl GameInfo {
     }
 
     pub(crate) const fn should_prune(&self) -> bool {
-        const CYCLE_LIMIT: u32 = 5;
+        const CYCLE_LIMIT: u32 = 6;
         self.last_seen > CYCLE_LIMIT
     }
 


### PR DESCRIPTION
Creates a number of groups where all the players within a group are friends with each other. Can be used to visualise which players are friends with each other on a server, and is often indicative of which players are queued in parties on casual servers (although these are only friend relations).

e.g.
![image](https://github.com/MegaAntiCheat/client-backend/assets/47521168/b00eade0-a819-4522-b3f6-d5732064c14e)