### PR TITLE
Enable ansi support on windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -371,6 +380,7 @@ checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
 name = "client-backend"
 version = "0.1.0"
 dependencies = [
+ "ansi_term",
  "anyhow",
  "atomic-write-file",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ tokio-tungstenite = { version = "0.23.1", features = ["native-tls"] }
 atomic-write-file = "0.1.4"
 uuid = { version = "1.9.1", features = ["serde", "v4"] }
 pot = "3.0.0"
+ansi_term = "0.12.1"
 
 [build-dependencies]
 embed-resource = "2.4.2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,6 +104,12 @@ define_events!(
 fn main() {
     let _guard = init_tracing();
 
+    // Enable ANSI support for Windows
+    let ansi_res = ansi_term::enable_ansi_support();
+    if let Err(code) = ansi_res {
+        tracing::warn!("Failed to enable ANSI support. Error code: {:?}", code);
+    }
+
     let args = Args::parse();
 
     let settings = Settings::load_or_create(&args);

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,15 +100,20 @@ define_events!(
     },
 );
 
-#[allow(clippy::too_many_lines)]
-fn main() {
-    let _guard = init_tracing();
-
-    // Enable ANSI support for Windows
+#[cfg(target_os = "windows")]
+fn enable_ansi() {
     let ansi_res = ansi_term::enable_ansi_support();
     if let Err(code) = ansi_res {
         tracing::warn!("Failed to enable ANSI support. Error code: {:?}", code);
     }
+}
+
+#[allow(clippy::too_many_lines)]
+fn main() {
+    let _guard = init_tracing();
+
+    #[cfg(target_os = "windows")]
+    enable_ansi();
 
     let args = Args::parse();
 


### PR DESCRIPTION
On windows (at least for me and someone in [this discord thread](https://discord.com/channels/1112665618869661726/1223791721817706557)) the client_backend console is missing its ansi formatting

![image](https://github.com/user-attachments/assets/4acf58dc-2383-46b8-a22b-bd09e8449a51)

This uses ansi_term::enable_ansi_support to make the formatting work on windows too.

![image](https://github.com/user-attachments/assets/03541244-8501-46a1-8625-b934e6340326)

I have almost no experience with rust but it seems to work fine for me on windows and wsl.
