### PR TITLE
Add "Record All Matches" in autoexec

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The client app for [MAC](https://github.com/MegaAntiCheat)
 ip 0.0.0.0
 rcon_password mac_rcon
 net_start
+ds_enable 2
 ```
 4. If you use mastercomfig, you will have to put your `autoexec.cfg` inside the `overrides` folder instead ([more information](https://docs.mastercomfig.com/9.9.3/customization/custom_configs))
 5. Launch TF2


### PR DESCRIPTION
This pull request adds a command to automatically enable the demo recording feature upon launch of Team Fortress 2. This change addresses an issue where demo recording may be disabled automatically upon launch due to settings configured in mastercomfig and saved to Steam Cloud requiring manual re-enabling each time the game starts.

The primary function of the Megaanticheat tool is to upload recorded demos. Enabling demo recording by default aligns with the tool's purpose and eliminates the need for users to manually adjust settings each time they launch the game. Users who prefer not to record demos can simply remove the line.