### PR TITLE
Configure TF2 to listen only on loopback interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The client app for [MAC](https://github.com/MegaAntiCheat)
 2. Add `-condebug -conclearlog -usercon -g15` to your TF2 launch options (Right click the game in your library -> `Properties...`)
 3. Add the following lines to your `autoexec.cfg` file ([learn how to find yours here](https://steamcommunity.com/sharedfiles/filedetails/?id=3112357964))
 ```
-ip 0.0.0.0
+ip 127.0.0.1
 rcon_password mac_rcon
 net_start
 ```
@@ -33,10 +33,10 @@ net_start
   - Ensure your `autoexec.cfg` is executing properly
   - Check step 4 of *Usage steps* if you use Mastercomfig
   - Make sure you haven't accidentally made it `autoexec.cfg.txt` (you might need to [show file extensions](https://www.howtogeek.com/205086/beginner-how-to-make-windows-show-file-extensions/))
-  - When you launch TF2, open your console and look for a line that looks like `Network: IP 0.0.0.0, mode MP, dedicated No, ports 27015 SV / 27005 CL`
+  - When you launch TF2, open your console and look for a line that looks like `Network: IP 127.0.0.1, mode MP, dedicated No, ports 27015 SV / 27005 CL`
     - If you see this line, `autoexec.cfg` it is being executed
     - If you do not have this line in your console, your `autoexec.cfg` is not being executed
-  - Restart TF2, then paste the commands `ip 0.0.0.0`, `rcon_password mac_rcon` and `net_start` into your console manually
+  - Restart TF2, then paste the commands `ip 127.0.0.1`, `rcon_password mac_rcon` and `net_start` into your console manually
     - Restart client-backend and see if it can connect afterwards
     - If it successfully connects after that, your `autoexec.cfg` file is not executing
   - Another program may be using that port, you can try change the rcon port that MAC will use


### PR DESCRIPTION
This way only the local machine where tf2 is running is able to access the remote console. If listening on 0.0.0.0, and the machine doesn't have a firewall, any other computer that can reach the machine running tf2 can access the rcon.