### PR TITLE
Late bytes fixes and broadcast support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,7 +378,7 @@ checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
 
 [[package]]
 name = "client-backend"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -1689,9 +1689,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
 name = "open"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 workspace = { members = ["event_loop"] }
 [package]
 name = "client-backend"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 build = "build.rs"
 

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -72,10 +72,10 @@ pub struct LateBytes {
 }
 
 impl LateBytes {
-    pub fn to_hex(&self) -> String {
+    #[must_use] pub fn to_hex(&self) -> String {
         self.bytes
             .iter()
-            .map(|byte| format!("{:02x}", byte))
+            .map(|byte| format!("{byte:02x}"))
             .collect()
     }
 }

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -72,11 +72,11 @@ pub struct LateBytes {
 }
 
 impl LateBytes {
-    #[must_use] pub fn to_hex(&self) -> String {
+    #[must_use]
+    pub fn to_hex(&self) -> String {
         self.bytes
             .iter()
-            .map(|byte| format!("{byte:02x}"))
-            .collect()
+            .fold(String::new(), |acc, byte| format!("{acc}{byte:02x}"))
     }
 }
 
@@ -378,11 +378,8 @@ impl DemoManager {
         let current_metadata = metadata(file_path)?;
 
         // Check the file is long enough to have data at the late byte address
-        match current_metadata.len().cmp(&min_valid_filelen) {
-            std::cmp::Ordering::Less => {
-                return Ok(None);
-            }
-            _ => {}
+        if current_metadata.len().cmp(&min_valid_filelen) == std::cmp::Ordering::Less {
+            return Ok(None);
         }
 
         let mut file = File::open(file_path)?;

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -67,6 +67,17 @@ pub struct DemoBytes {
 }
 impl<S> event_loop::Message<S> for DemoBytes {}
 
+pub struct LateBytes {
+    bytes: [u8; 16],
+}
+
+impl LateBytes {
+    pub fn to_hex(&self) -> String
+    {
+        self.bytes.iter().map(|byte| format!("{:02x}", byte)).collect()
+    }
+}
+
 #[allow(clippy::module_name_repetitions)]
 pub struct DemoWatcher {
     recv: Receiver<Event>,
@@ -353,7 +364,7 @@ impl DemoManager {
     ///
     /// # Errors
     /// On IO errors
-    fn read_late_bytes(&self) -> std::io::Result<Option<Vec<u8>>> {
+    fn read_late_bytes(&self) -> std::io::Result<Option<LateBytes>> {
         let Some(file_path) = self.current_demo_path() else {
             return Ok(None);
         };
@@ -369,7 +380,7 @@ impl DemoManager {
             std::cmp::Ordering::Less => {
                 return Ok(None);
             }
-            std::cmp::Ordering::Equal | std::cmp::Ordering::Greater => {}
+            _ => {}
         }
 
         let mut file = File::open(file_path)?;
@@ -384,9 +395,11 @@ impl DemoManager {
 
         if written {
             tracing::debug!("Late bytes found in demo recording.");
-            Ok(Some(out))
+            let mut late_bytes: LateBytes = LateBytes { bytes: [0u8; 16] };
+            late_bytes.bytes.copy_from_slice(&out);
+            Ok(Some(late_bytes))
         } else {
-            tracing::debug!("No new bytes from demo.");
+            tracing::debug!("No late bytes from demo.");
             Ok(None)
         }
     }
@@ -425,7 +438,7 @@ impl DemoManager {
     /// Returns an event that checks for and handles the late bytes for the
     /// current demo.
     /// This event needs to be handled by the event loop to take effect.
-    fn handle_late_bytes<M: Is<DemoMessage>>(&self, late_bytes: Vec<u8>) -> Option<Handled<M>> {
+    fn handle_late_bytes<M: Is<DemoMessage>>(&self, late_bytes: LateBytes) -> Option<Handled<M>> {
         let mut session = self.session.clone();
         Handled::future(async move {
             let mut session_lock = session.get().await;

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -72,9 +72,11 @@ pub struct LateBytes {
 }
 
 impl LateBytes {
-    pub fn to_hex(&self) -> String
-    {
-        self.bytes.iter().map(|byte| format!("{:02x}", byte)).collect()
+    pub fn to_hex(&self) -> String {
+        self.bytes
+            .iter()
+            .map(|byte| format!("{:02x}", byte))
+            .collect()
     }
 }
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -175,8 +175,14 @@ impl Message<MACState> for GitHubVersionResponse {
 }
 
 pub struct GitHubVersionHandler;
+impl Default for GitHubVersionHandler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl GitHubVersionHandler {
-    pub fn new() -> Self {
+    #[must_use] pub fn new() -> Self {
         Self
     }
 }
@@ -195,7 +201,7 @@ where
             return None;
         }
         Handled::future(async move {
-            let endpoint = format!("https://api.github.com/repos/{}/releases", UPDATE_REPO);
+            let endpoint = format!("https://api.github.com/repos/{UPDATE_REPO}/releases");
             let response = match reqwest::Client::new()
                 .get(endpoint)
                 .header("Accept", "application/vnd.github+json")
@@ -233,7 +239,7 @@ where
                 None => {
                     return Some(OM::from(GitHubVersionResponse {
                         latest_version: MAC_VERSION.to_owned(),
-                        tx: tx,
+                        tx,
                     }));
                 }
             };
@@ -243,14 +249,14 @@ where
                 None => {
                     return Some(OM::from(GitHubVersionResponse {
                         latest_version: MAC_VERSION.to_owned(),
-                        tx: tx,
+                        tx,
                     }));
                 }
             };
 
             let broadcast_response: GitHubVersionResponse = GitHubVersionResponse {
                 latest_version: latest_release.unwrap_or(MAC_VERSION).to_string(),
-                tx: tx,
+                tx,
             };
 
             Some(OM::from(broadcast_response))

--- a/src/events.rs
+++ b/src/events.rs
@@ -7,7 +7,12 @@ use serde_json::Value;
 use steamid_ng::SteamID;
 use tokio::sync::mpsc::{Receiver, UnboundedSender};
 
-use crate::{player_records::Verdict, settings::FriendsAPIUsage, state::MACState, web::{MAC_VERSION, UPDATE_REPO}};
+use crate::{
+    player_records::Verdict,
+    settings::FriendsAPIUsage,
+    state::MACState,
+    web::{MAC_VERSION, UPDATE_REPO},
+};
 
 #[derive(Debug, Clone, Copy)]
 pub struct Refresh;
@@ -154,7 +159,7 @@ impl Message<MACState> for Preferences {
 }
 
 pub struct GitHubVersionLookup {
-    pub tx: UnboundedSender<String>
+    pub tx: UnboundedSender<String>,
 }
 
 impl Message<MACState> for GitHubVersionLookup {
@@ -178,7 +183,7 @@ impl GitHubVersionHandler {
 
 impl<IM, OM> MessageHandler<MACState, IM, OM> for GitHubVersionHandler
 where
-    IM: Is<GitHubVersionLookup> ,
+    IM: Is<GitHubVersionLookup>,
     OM: Is<GitHubVersionResponse>,
 {
     fn handle_message(&mut self, _: &MACState, message: &IM) -> Option<event_loop::Handled<OM>> {
@@ -206,36 +211,46 @@ where
                 }
             };
 
-            let response_json: Value = response.json().await.expect("Failed to parse github release info");
+            let response_json: Value = response
+                .json()
+                .await
+                .expect("Failed to parse github release info");
             let default = &vec![];
-            let latest_release_json = response_json.as_array()
-                .unwrap_or(default)
-                .iter()
-                .find(|r| r.as_object().unwrap().get("draft").is_some_and(|d| d.as_bool().is_some_and(|d| !d)));
+            let latest_release_json =
+                response_json
+                    .as_array()
+                    .unwrap_or(default)
+                    .iter()
+                    .find(|r| {
+                        r.as_object()
+                            .unwrap()
+                            .get("draft")
+                            .is_some_and(|d| d.as_bool().is_some_and(|d| !d))
+                    });
 
             let latest_release_json = match latest_release_json {
                 Some(lr) => lr.to_owned(),
                 None => {
                     return Some(OM::from(GitHubVersionResponse {
                         latest_version: MAC_VERSION.to_owned(),
-                        tx: tx
+                        tx: tx,
                     }));
-                },
+                }
             };
-            
+
             let latest_release = match latest_release_json.get("tag_name") {
                 Some(lr) => lr.as_str(),
                 None => {
                     return Some(OM::from(GitHubVersionResponse {
                         latest_version: MAC_VERSION.to_owned(),
-                        tx: tx
+                        tx: tx,
                     }));
-                },
+                }
             };
 
             let broadcast_response: GitHubVersionResponse = GitHubVersionResponse {
                 latest_version: latest_release.unwrap_or(MAC_VERSION).to_string(),
-                tx: tx
+                tx: tx,
             };
 
             Some(OM::from(broadcast_response))

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,12 +1,13 @@
 use std::{collections::HashMap, path::PathBuf, time::Duration};
 
 use chrono::DateTime;
-use event_loop::Message;
+use event_loop::{try_get, Handled, Is, Message, MessageHandler};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use steamid_ng::SteamID;
-use tokio::sync::mpsc::Receiver;
+use tokio::sync::mpsc::{Receiver, UnboundedSender};
 
-use crate::{player_records::Verdict, settings::FriendsAPIUsage, state::MACState};
+use crate::{player_records::Verdict, settings::FriendsAPIUsage, state::MACState, web::{MAC_VERSION, UPDATE_REPO}};
 
 #[derive(Debug, Clone, Copy)]
 pub struct Refresh;
@@ -149,5 +150,95 @@ impl Message<MACState> for Preferences {
         }
 
         state.settings.save_ok();
+    }
+}
+
+pub struct GitHubVersionLookup {
+    pub tx: UnboundedSender<String>
+}
+
+impl Message<MACState> for GitHubVersionLookup {
+    fn update_state(self, _: &mut MACState) {}
+}
+pub struct GitHubVersionResponse {
+    pub latest_version: String,
+    pub tx: UnboundedSender<String>,
+}
+
+impl Message<MACState> for GitHubVersionResponse {
+    fn update_state(self, _: &mut MACState) {}
+}
+
+pub struct GitHubVersionHandler;
+impl GitHubVersionHandler {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl<IM, OM> MessageHandler<MACState, IM, OM> for GitHubVersionHandler
+where
+    IM: Is<GitHubVersionLookup> ,
+    OM: Is<GitHubVersionResponse>,
+{
+    fn handle_message(&mut self, _: &MACState, message: &IM) -> Option<event_loop::Handled<OM>> {
+        let tx;
+        if let Some(msg) = try_get::<GitHubVersionLookup>(message) {
+            tx = msg.tx.clone();
+            tracing::debug!("Attempting to fetch latest version from GitHub");
+        } else {
+            return None;
+        }
+        Handled::future(async move {
+            let endpoint = format!("https://api.github.com/repos/{}/releases", UPDATE_REPO);
+            let response = match reqwest::Client::new()
+                .get(endpoint)
+                .header("Accept", "application/vnd.github+json")
+                .header("User-Agent", "reqwest")
+                .send()
+                .await
+            {
+                Ok(r) => r,
+                Err(e) => {
+                    // TODO: prevent this error from being spammed when connection dies.
+                    tracing::error!("Failed to get github release info: {:?}", e);
+                    return None;
+                }
+            };
+
+            let response_json: Value = response.json().await.expect("Failed to parse github release info");
+            let default = &vec![];
+            let latest_release_json = response_json.as_array()
+                .unwrap_or(default)
+                .iter()
+                .find(|r| r.as_object().unwrap().get("draft").is_some_and(|d| d.as_bool().is_some_and(|d| !d)));
+
+            let latest_release_json = match latest_release_json {
+                Some(lr) => lr.to_owned(),
+                None => {
+                    return Some(OM::from(GitHubVersionResponse {
+                        latest_version: MAC_VERSION.to_owned(),
+                        tx: tx
+                    }));
+                },
+            };
+            
+            let latest_release = match latest_release_json.get("tag_name") {
+                Some(lr) => lr.as_str(),
+                None => {
+                    return Some(OM::from(GitHubVersionResponse {
+                        latest_version: MAC_VERSION.to_owned(),
+                        tx: tx
+                    }));
+                },
+            };
+
+            let broadcast_response: GitHubVersionResponse = GitHubVersionResponse {
+                latest_version: latest_release.unwrap_or(MAC_VERSION).to_string(),
+                tx: tx
+            };
+
+            Some(OM::from(broadcast_response))
+        })
     }
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -182,7 +182,8 @@ impl Default for GitHubVersionHandler {
 }
 
 impl GitHubVersionHandler {
-    #[must_use] pub fn new() -> Self {
+    #[must_use]
+    pub fn new() -> Self {
         Self
     }
 }
@@ -228,9 +229,7 @@ where
                     .unwrap_or(default)
                     .iter()
                     .find(|r| {
-                        r.as_object()
-                            .unwrap()
-                            .get("draft")
+                        r.get("draft")
                             .is_some_and(|d| d.as_bool().is_some_and(|d| !d))
                     });
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,10 +13,7 @@ use clap::Parser;
 use event_loop::{define_events, EventLoop};
 use events::{emit_on_timer, GitHubVersionHandler, GitHubVersionLookup, GitHubVersionResponse};
 use launchoptions::LaunchOptions;
-use masterbase::{
-    MasterbaseBroadcastHandler, MasterbaseBroadcastLookup, MasterbaseBroadcastResponse,
-    MasterbaseBroadcastTick,
-};
+use masterbase::{BroadcastHandler, BroadcastLookup, BroadcastResponse, BroadcastTick};
 use player::Players;
 use player_records::PlayerRecords;
 use reqwest::StatusCode;
@@ -87,9 +84,9 @@ define_events!(
         DemoBytes,
         DemoMessage,
 
-        MasterbaseBroadcastTick,
-        MasterbaseBroadcastLookup,
-        MasterbaseBroadcastResponse,
+        BroadcastTick,
+        BroadcastLookup,
+        BroadcastResponse,
 
         GitHubVersionLookup,
         GitHubVersionResponse
@@ -105,7 +102,7 @@ define_events!(
         WebAPIHandler,
         SseEventBroadcaster,
 
-        MasterbaseBroadcastHandler,
+        BroadcastHandler,
         GitHubVersionHandler,
 
         DemoManager,
@@ -249,7 +246,7 @@ fn main() {
                 .add_source(console_log)
                 .add_source(emit_on_timer(Duration::from_secs(3), || Refresh).await)
                 .add_source(emit_on_timer(Duration::from_millis(500), || ProfileLookupBatchTick).await)
-                .add_source(emit_on_timer(Duration::from_secs(15), || MasterbaseBroadcastTick).await)
+                .add_source(emit_on_timer(Duration::from_secs(15), || BroadcastTick).await)
                 .add_source(Box::new(web_requests))
                 .add_handler(DemoManager::new())
                 .add_handler(CommandManager::new())
@@ -259,7 +256,7 @@ fn main() {
                 .add_handler(LookupFriends::new())
                 .add_handler(DumbAutoKick)
                 .add_handler(WebAPIHandler::new())
-                .add_handler(MasterbaseBroadcastHandler::new())
+                .add_handler(BroadcastHandler::new())
                 .add_handler(GitHubVersionHandler)
                 .add_handler(SseEventBroadcaster::new());
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use std::{
 use args::Args;
 use clap::Parser;
 use event_loop::{define_events, EventLoop};
-use events::emit_on_timer;
+use events::{emit_on_timer, GitHubVersionHandler, GitHubVersionLookup, GitHubVersionResponse};
 use launchoptions::LaunchOptions;
 use masterbase::{MasterbaseBroadcastHandler, MasterbaseBroadcastLookup, MasterbaseBroadcastResponse, MasterbaseBroadcastTick};
 use player::Players;
@@ -87,6 +87,9 @@ define_events!(
         MasterbaseBroadcastTick,
         MasterbaseBroadcastLookup,
         MasterbaseBroadcastResponse,
+
+        GitHubVersionLookup,
+        GitHubVersionResponse
     },
     Handler {
         CommandManager,
@@ -100,6 +103,7 @@ define_events!(
         SseEventBroadcaster,
         
         MasterbaseBroadcastHandler,
+        GitHubVersionHandler,
 
         DemoManager,
         PrintVotes,
@@ -253,6 +257,7 @@ fn main() {
                 .add_handler(DumbAutoKick)
                 .add_handler(WebAPIHandler::new())
                 .add_handler(MasterbaseBroadcastHandler::new())
+                .add_handler(GitHubVersionHandler)
                 .add_handler(SseEventBroadcaster::new());
 
             if args.print_votes {

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use clap::Parser;
 use event_loop::{define_events, EventLoop};
 use events::emit_on_timer;
 use launchoptions::LaunchOptions;
+use masterbase::MasterbaseBroadcastLookup;
 use player::Players;
 use player_records::PlayerRecords;
 use reqwest::StatusCode;
@@ -235,6 +236,7 @@ fn main() {
                 .add_source(console_log)
                 .add_source(emit_on_timer(Duration::from_secs(3), || Refresh).await)
                 .add_source(emit_on_timer(Duration::from_millis(500), || ProfileLookupBatchTick).await)
+                .add_source(emit_on_timer(Duration::from_secs(15), || MasterbaseBroadcastLookup).await)
                 .add_source(Box::new(web_requests))
                 .add_handler(DemoManager::new())
                 .add_handler(CommandManager::new())

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use clap::Parser;
 use event_loop::{define_events, EventLoop};
 use events::emit_on_timer;
 use launchoptions::LaunchOptions;
-use masterbase::MasterbaseBroadcastLookup;
+use masterbase::{MasterbaseBroadcastHandler, MasterbaseBroadcastLookup, MasterbaseBroadcastResponse, MasterbaseBroadcastTick};
 use player::Players;
 use player_records::PlayerRecords;
 use reqwest::StatusCode;
@@ -83,6 +83,10 @@ define_events!(
 
         DemoBytes,
         DemoMessage,
+
+        MasterbaseBroadcastTick,
+        MasterbaseBroadcastLookup,
+        MasterbaseBroadcastResponse,
     },
     Handler {
         CommandManager,
@@ -94,6 +98,8 @@ define_events!(
 
         WebAPIHandler,
         SseEventBroadcaster,
+        
+        MasterbaseBroadcastHandler,
 
         DemoManager,
         PrintVotes,
@@ -236,7 +242,7 @@ fn main() {
                 .add_source(console_log)
                 .add_source(emit_on_timer(Duration::from_secs(3), || Refresh).await)
                 .add_source(emit_on_timer(Duration::from_millis(500), || ProfileLookupBatchTick).await)
-                .add_source(emit_on_timer(Duration::from_secs(15), || MasterbaseBroadcastLookup).await)
+                .add_source(emit_on_timer(Duration::from_secs(15), || MasterbaseBroadcastTick).await)
                 .add_source(Box::new(web_requests))
                 .add_handler(DemoManager::new())
                 .add_handler(CommandManager::new())
@@ -246,6 +252,7 @@ fn main() {
                 .add_handler(LookupFriends::new())
                 .add_handler(DumbAutoKick)
                 .add_handler(WebAPIHandler::new())
+                .add_handler(MasterbaseBroadcastHandler::new())
                 .add_handler(SseEventBroadcaster::new());
 
             if args.print_votes {

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,10 @@ use clap::Parser;
 use event_loop::{define_events, EventLoop};
 use events::{emit_on_timer, GitHubVersionHandler, GitHubVersionLookup, GitHubVersionResponse};
 use launchoptions::LaunchOptions;
-use masterbase::{MasterbaseBroadcastHandler, MasterbaseBroadcastLookup, MasterbaseBroadcastResponse, MasterbaseBroadcastTick};
+use masterbase::{
+    MasterbaseBroadcastHandler, MasterbaseBroadcastLookup, MasterbaseBroadcastResponse,
+    MasterbaseBroadcastTick,
+};
 use player::Players;
 use player_records::PlayerRecords;
 use reqwest::StatusCode;
@@ -101,7 +104,7 @@ define_events!(
 
         WebAPIHandler,
         SseEventBroadcaster,
-        
+
         MasterbaseBroadcastHandler,
         GitHubVersionHandler,
 

--- a/src/masterbase.rs
+++ b/src/masterbase.rs
@@ -3,6 +3,7 @@ use std::{
     fmt::{Debug, Display},
 };
 
+use chrono::{DateTime, Utc};
 use futures::SinkExt;
 use reqwest::{Client, RequestBuilder, Response};
 use serde::{Deserialize, Serialize};
@@ -284,3 +285,24 @@ pub async fn force_close_session(host: &str, key: &str, http: bool) -> Result<Re
 
     Ok(reqwest::get(url).await?)
 }
+
+#[derive(Serialize)]
+pub enum MasterbaseBroadcastImportance {
+    INFO,
+    UPDATE,
+    WARNING,
+    CRITICAL
+}
+
+#[derive(Serialize)]
+pub struct MasterbaseBroadcastResponse {
+    pub latest_update: DateTime<Utc>,
+    pub broadcasts: Vec<MasterbaseBroadcast>,
+}
+#[derive(Serialize)]
+pub struct MasterbaseBroadcast {
+    pub message: String,
+    pub post_date: DateTime<Utc>,
+    pub importance: MasterbaseBroadcastImportance,
+}
+pub struct MasterbaseBroadcastLookup;

--- a/src/masterbase.rs
+++ b/src/masterbase.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use chrono::{DateTime, Utc};
+use event_loop::{try_get, Handled, Is, Message, MessageHandler};
 use futures::SinkExt;
 use reqwest::{Client, RequestBuilder, Response};
 use serde::{Deserialize, Serialize};
@@ -12,7 +13,7 @@ use thiserror::Error;
 use tokio::{net::TcpStream, sync::mpsc::Sender};
 use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
 
-use crate::{demo::LateBytes, player_records::Verdict};
+use crate::{demo::LateBytes, player_records::Verdict, state::MACState};
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -286,7 +287,9 @@ pub async fn force_close_session(host: &str, key: &str, http: bool) -> Result<Re
     Ok(reqwest::get(url).await?)
 }
 
-#[derive(Serialize)]
+// Masterbase Broadcasts
+
+#[derive(Serialize, Deserialize, Clone)]
 pub enum MasterbaseBroadcastImportance {
     INFO,
     UPDATE,
@@ -294,15 +297,75 @@ pub enum MasterbaseBroadcastImportance {
     CRITICAL
 }
 
-#[derive(Serialize)]
-pub struct MasterbaseBroadcastResponse {
-    pub latest_update: DateTime<Utc>,
-    pub broadcasts: Vec<MasterbaseBroadcast>,
-}
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct MasterbaseBroadcast {
     pub message: String,
     pub post_date: DateTime<Utc>,
     pub importance: MasterbaseBroadcastImportance,
 }
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct MasterbaseBroadcastResponse {
+    pub latest_update: DateTime<Utc>,
+    pub broadcasts: Vec<MasterbaseBroadcast>,
+}
+impl Message<MACState> for MasterbaseBroadcastResponse {
+    fn update_state(self, _: &mut MACState) {}
+}
+
+pub struct MasterbaseBroadcastTick;
+impl<S> event_loop::Message<S> for MasterbaseBroadcastTick {}
+
 pub struct MasterbaseBroadcastLookup;
+impl Message<MACState> for MasterbaseBroadcastLookup {
+    fn update_state(self, _: &mut MACState) {}
+}
+
+pub struct MasterbaseBroadcastHandler;
+impl MasterbaseBroadcastHandler {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl<IM, OM> MessageHandler<MACState, IM, OM> for MasterbaseBroadcastHandler
+where
+    IM: Is<MasterbaseBroadcastLookup> + Is<MasterbaseBroadcastTick>,
+    OM: Is<MasterbaseBroadcastResponse>,
+{
+    fn handle_message(&mut self, state: &MACState, message: &IM) -> Option<event_loop::Handled<OM>> {
+
+        if let Some(_) = try_get::<MasterbaseBroadcastLookup>(message) {
+            tracing::debug!("Masterbase Broadcast request triggered by MasterbaseBroadcastLookup");
+        } else if let Some(_) = try_get::<MasterbaseBroadcastTick>(message) {
+            tracing::debug!("Masterbase Broadcast request triggered by MasterbaseBroadcastTick");
+        } else {
+            return None;
+        }
+
+        let http = state.settings.use_masterbase_http();
+        let masterbase_host = state.settings.masterbase_host().to_owned();
+        Handled::future(async move {
+            let client = Client::new();
+            let endpoint = if http {
+                format!("http://{}/broadcasts", masterbase_host)
+            } else {
+                format!("https://{}/broadcasts", masterbase_host)
+            };
+
+            tracing::debug!("GET: {}", endpoint);
+            let response = match client.get(&endpoint).send().await {
+                Ok(r) => r,
+                Err(e) => {
+                    // TODO: prevent this error from being spammed when connection dies.
+                    tracing::error!("Failed to get broadcasts: {:?}", e);
+                    return None;
+                }
+            };
+
+            let broadcasts: MasterbaseBroadcastResponse = response.json().await.expect("Failed to parse broadcasts");
+
+            Some(OM::from(broadcasts.clone()))
+        })
+    }
+}

--- a/src/masterbase.rs
+++ b/src/masterbase.rs
@@ -232,12 +232,12 @@ impl DemoSession {
     /// # Errors
     /// If the web request to send late bytes was unsuccessful
     pub async fn send_late_bytes(&self, bytes: LateBytes) -> Result<Response, Error> {
-        tracing::debug!("Sending late bytes");
-
         #[derive(Serialize)]
         struct LateBytesBody {
             late_bytes: String,
         }
+
+        tracing::debug!("Sending late bytes");
 
         let params = [("api_key", &self.key)];
 
@@ -288,7 +288,8 @@ pub async fn force_close_session(host: &str, key: &str, http: bool) -> Result<Re
 // Masterbase Broadcasts
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
-pub enum MasterbaseBroadcastImportance {
+#[allow(clippy::upper_case_acronyms)]
+pub enum BroadcastImportance {
     INFO,
     UPDATE,
     WARNING,
@@ -296,55 +297,56 @@ pub enum MasterbaseBroadcastImportance {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct MasterbaseBroadcast {
+pub struct Broadcast {
     pub message: String,
     pub post_date: DateTime<Utc>,
-    pub importance: MasterbaseBroadcastImportance,
+    pub importance: BroadcastImportance,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct MasterbaseBroadcastResponse {
+pub struct BroadcastResponse {
     pub latest_update: DateTime<Utc>,
-    pub broadcasts: Vec<MasterbaseBroadcast>,
+    pub broadcasts: Vec<Broadcast>,
 }
-impl Message<MACState> for MasterbaseBroadcastResponse {
+impl Message<MACState> for BroadcastResponse {
     fn update_state(self, _: &mut MACState) {}
 }
 
-pub struct MasterbaseBroadcastTick;
-impl<S> event_loop::Message<S> for MasterbaseBroadcastTick {}
+pub struct BroadcastTick;
+impl<S> event_loop::Message<S> for BroadcastTick {}
 
-pub struct MasterbaseBroadcastLookup;
-impl Message<MACState> for MasterbaseBroadcastLookup {
+pub struct BroadcastLookup;
+impl Message<MACState> for BroadcastLookup {
     fn update_state(self, _: &mut MACState) {}
 }
 
-pub struct MasterbaseBroadcastHandler;
-impl Default for MasterbaseBroadcastHandler {
+pub struct BroadcastHandler;
+impl Default for BroadcastHandler {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl MasterbaseBroadcastHandler {
-    #[must_use] pub fn new() -> Self {
+impl BroadcastHandler {
+    #[must_use]
+    pub fn new() -> Self {
         Self
     }
 }
 
-impl<IM, OM> MessageHandler<MACState, IM, OM> for MasterbaseBroadcastHandler
+impl<IM, OM> MessageHandler<MACState, IM, OM> for BroadcastHandler
 where
-    IM: Is<MasterbaseBroadcastLookup> + Is<MasterbaseBroadcastTick>,
-    OM: Is<MasterbaseBroadcastResponse>,
+    IM: Is<BroadcastLookup> + Is<BroadcastTick>,
+    OM: Is<BroadcastResponse>,
 {
     fn handle_message(
         &mut self,
         state: &MACState,
         message: &IM,
     ) -> Option<event_loop::Handled<OM>> {
-        if try_get::<MasterbaseBroadcastLookup>(message).is_some() {
+        if try_get::<BroadcastLookup>(message).is_some() {
             tracing::debug!("Masterbase Broadcast request triggered by MasterbaseBroadcastLookup");
-        } else if try_get::<MasterbaseBroadcastTick>(message).is_some() {
+        } else if try_get::<BroadcastTick>(message).is_some() {
             tracing::debug!("Masterbase Broadcast request triggered by MasterbaseBroadcastTick");
         } else {
             return None;
@@ -371,7 +373,7 @@ where
             };
 
             let broadcasts = response.json().await.expect("Failed to parse broadcasts");
-            let broadcast_response: MasterbaseBroadcastResponse = MasterbaseBroadcastResponse {
+            let broadcast_response: BroadcastResponse = BroadcastResponse {
                 latest_update: Utc::now(),
                 broadcasts,
             };

--- a/src/masterbase.rs
+++ b/src/masterbase.rs
@@ -289,7 +289,7 @@ pub async fn force_close_session(host: &str, key: &str, http: bool) -> Result<Re
 
 // Masterbase Broadcasts
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub enum MasterbaseBroadcastImportance {
     INFO,
     UPDATE,
@@ -297,14 +297,14 @@ pub enum MasterbaseBroadcastImportance {
     CRITICAL
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct MasterbaseBroadcast {
     pub message: String,
     pub post_date: DateTime<Utc>,
     pub importance: MasterbaseBroadcastImportance,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct MasterbaseBroadcastResponse {
     pub latest_update: DateTime<Utc>,
     pub broadcasts: Vec<MasterbaseBroadcast>,
@@ -363,9 +363,13 @@ where
                 }
             };
 
-            let broadcasts: MasterbaseBroadcastResponse = response.json().await.expect("Failed to parse broadcasts");
+            let broadcasts = response.json().await.expect("Failed to parse broadcasts");
+            let broadcast_response: MasterbaseBroadcastResponse = MasterbaseBroadcastResponse {
+                latest_update: Utc::now(),
+                broadcasts                
+            };
 
-            Some(OM::from(broadcasts.clone()))
+            Some(OM::from(broadcast_response.clone()))
         })
     }
 }

--- a/src/masterbase.rs
+++ b/src/masterbase.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::HashMap,
-    fmt::{Debug, Display, Write},
+    fmt::{Debug, Display},
 };
 
 use futures::SinkExt;
@@ -11,7 +11,7 @@ use thiserror::Error;
 use tokio::{net::TcpStream, sync::mpsc::Sender};
 use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
 
-use crate::player_records::Verdict;
+use crate::{demo::LateBytes, player_records::Verdict};
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -229,35 +229,28 @@ impl DemoSession {
 
     /// # Errors
     /// If the web request to send late bytes was unsuccessful
-    pub async fn send_late_bytes(&self, bytes: Vec<u8>) -> Result<Response, Error> {
+    pub async fn send_late_bytes(&self, bytes: LateBytes) -> Result<Response, Error> {
+        tracing::debug!("Sending late bytes");
+
         #[derive(Serialize)]
-        struct LateBytes {
+        struct LateBytesBody {
             late_bytes: String,
         }
 
-        tracing::debug!("Sending late bytes");
-
-        let params = [("api_key", &self.key)];
+        let params = [
+            ("api_key", &self.key),
+        ];
 
         let endpoint = if self.http {
-            format!("http://{}/late_bytes", self.host)
+            format!("http://{}/close_session", self.host)
         } else {
-            format!("https://{}/late_bytes", self.host)
+            format!("https://{}/close_session", self.host)
         };
 
-        let url = reqwest::Url::parse_with_params(&endpoint, params)?;
-
         let client = Client::new();
-        let late_bytes_hex: String =
-            bytes
-                .iter()
-                .fold(String::with_capacity(bytes.len() * 2), |mut s, byte| {
-                    write!(&mut s, "{byte:02x}").expect("Couldn't write to string??");
-                    s
-                });
-
-        let req: RequestBuilder = client.post(url).json(&LateBytes {
-            late_bytes: late_bytes_hex,
+        let url = reqwest::Url::parse_with_params(&endpoint, params)?;
+        let req: RequestBuilder = client.post(url).json(&LateBytesBody {
+            late_bytes: bytes.to_hex(),
         });
 
         Ok(req.send().await?)

--- a/src/masterbase.rs
+++ b/src/masterbase.rs
@@ -320,8 +320,14 @@ impl Message<MACState> for MasterbaseBroadcastLookup {
 }
 
 pub struct MasterbaseBroadcastHandler;
+impl Default for MasterbaseBroadcastHandler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl MasterbaseBroadcastHandler {
-    pub fn new() -> Self {
+    #[must_use] pub fn new() -> Self {
         Self
     }
 }
@@ -336,9 +342,9 @@ where
         state: &MACState,
         message: &IM,
     ) -> Option<event_loop::Handled<OM>> {
-        if let Some(_) = try_get::<MasterbaseBroadcastLookup>(message) {
+        if try_get::<MasterbaseBroadcastLookup>(message).is_some() {
             tracing::debug!("Masterbase Broadcast request triggered by MasterbaseBroadcastLookup");
-        } else if let Some(_) = try_get::<MasterbaseBroadcastTick>(message) {
+        } else if try_get::<MasterbaseBroadcastTick>(message).is_some() {
             tracing::debug!("Masterbase Broadcast request triggered by MasterbaseBroadcastTick");
         } else {
             return None;
@@ -349,9 +355,9 @@ where
         Handled::future(async move {
             let client = Client::new();
             let endpoint = if http {
-                format!("http://{}/broadcasts", masterbase_host)
+                format!("http://{masterbase_host}/broadcasts")
             } else {
-                format!("https://{}/broadcasts", masterbase_host)
+                format!("https://{masterbase_host}/broadcasts")
             };
 
             tracing::debug!("GET: {}", endpoint);

--- a/src/masterbase.rs
+++ b/src/masterbase.rs
@@ -239,9 +239,7 @@ impl DemoSession {
             late_bytes: String,
         }
 
-        let params = [
-            ("api_key", &self.key),
-        ];
+        let params = [("api_key", &self.key)];
 
         let endpoint = if self.http {
             format!("http://{}/close_session", self.host)
@@ -294,7 +292,7 @@ pub enum MasterbaseBroadcastImportance {
     INFO,
     UPDATE,
     WARNING,
-    CRITICAL
+    CRITICAL,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -333,8 +331,11 @@ where
     IM: Is<MasterbaseBroadcastLookup> + Is<MasterbaseBroadcastTick>,
     OM: Is<MasterbaseBroadcastResponse>,
 {
-    fn handle_message(&mut self, state: &MACState, message: &IM) -> Option<event_loop::Handled<OM>> {
-
+    fn handle_message(
+        &mut self,
+        state: &MACState,
+        message: &IM,
+    ) -> Option<event_loop::Handled<OM>> {
         if let Some(_) = try_get::<MasterbaseBroadcastLookup>(message) {
             tracing::debug!("Masterbase Broadcast request triggered by MasterbaseBroadcastLookup");
         } else if let Some(_) = try_get::<MasterbaseBroadcastTick>(message) {
@@ -366,7 +367,7 @@ where
             let broadcasts = response.json().await.expect("Failed to parse broadcasts");
             let broadcast_response: MasterbaseBroadcastResponse = MasterbaseBroadcastResponse {
                 latest_update: Utc::now(),
-                broadcasts                
+                broadcasts,
             };
 
             Some(OM::from(broadcast_response.clone()))

--- a/src/web.rs
+++ b/src/web.rs
@@ -28,7 +28,15 @@ use tokio_stream::wrappers::ReceiverStream;
 
 use super::command_manager::Command;
 use crate::{
-    events::{GitHubVersionLookup, GitHubVersionResponse, InternalPreferences, Preferences, UserUpdate, UserUpdates}, masterbase::{MasterbaseBroadcastLookup, MasterbaseBroadcastResponse}, player::{serialize_steamid_as_string, Friend, FriendInfo, Player, Players, SteamInfo}, server::Gamemode, state::MACState, steam_api::{request_steam_info, ProfileLookupResult}
+    events::{
+        GitHubVersionLookup, GitHubVersionResponse, InternalPreferences, Preferences, UserUpdate,
+        UserUpdates,
+    },
+    masterbase::{MasterbaseBroadcastLookup, MasterbaseBroadcastResponse},
+    player::{serialize_steamid_as_string, Friend, FriendInfo, Player, Players, SteamInfo},
+    server::Gamemode,
+    state::MACState,
+    steam_api::{request_steam_info, ProfileLookupResult},
 };
 const HEADERS: [(header::HeaderName, &str); 2] = [
     (header::CONTENT_TYPE, "application/json"),
@@ -76,16 +84,16 @@ pub struct WebAPIHandler {
 
 impl<IM, OM> MessageHandler<MACState, IM, OM> for WebAPIHandler
 where
-    IM: Is<WebRequest> +
-        Is<ProfileLookupResult> +
-        Is<MasterbaseBroadcastResponse> +
-        Is<GitHubVersionResponse>,
-    OM: Is<Command> +
-        Is<Preferences> +
-        Is<UserUpdates> +
-        Is<ProfileLookupResult> +
-        Is<MasterbaseBroadcastLookup> +
-        Is<GitHubVersionLookup>,
+    IM: Is<WebRequest>
+        + Is<ProfileLookupResult>
+        + Is<MasterbaseBroadcastResponse>
+        + Is<GitHubVersionResponse>,
+    OM: Is<Command>
+        + Is<Preferences>
+        + Is<UserUpdates>
+        + Is<ProfileLookupResult>
+        + Is<MasterbaseBroadcastLookup>
+        + Is<GitHubVersionLookup>,
 {
     #[allow(clippy::cognitive_complexity)]
     fn handle_message(
@@ -299,17 +307,21 @@ impl WebAPIHandler {
 
     // Masterbase status
 
-    fn get_masterbase_broadcasts_response<OM: Is<MasterbaseBroadcastLookup>>(&mut self, req: UnboundedSender<String>) -> Option<Handled<OM>> {
+    fn get_masterbase_broadcasts_response<OM: Is<MasterbaseBroadcastLookup>>(
+        &mut self,
+        req: UnboundedSender<String>,
+    ) -> Option<Handled<OM>> {
         if let Some(cache) = &self.masterbase_status_cache {
             if cache.latest_update + Duration::seconds(60) > Utc::now() {
-                req.send(serde_json::to_string(&cache).expect("Epic serialization fail")).ok();
+                req.send(serde_json::to_string(&cache).expect("Epic serialization fail"))
+                    .ok();
                 return Handled::none();
             } else {
                 self.masterbase_status_cache = None;
             }
         }
         if self.masterbase_status_cache.is_none() {
-            return Handled::single(MasterbaseBroadcastLookup)
+            return Handled::single(MasterbaseBroadcastLookup);
         }
         Handled::none()
     }
@@ -773,7 +785,11 @@ fn get_killfeed_response(state: &MACState) -> String {
 async fn get_masterbase_broadcasts(State(state): State<WebState>) -> impl IntoResponse {
     tracing::debug!("API: GET Masterbase broadcasts");
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-    if state.request.send(WebRequest::GetMasterbaseBroadcasts(tx)).is_err() {
+    if state
+        .request
+        .send(WebRequest::GetMasterbaseBroadcasts(tx))
+        .is_err()
+    {
         tracing::error!("Couldn't send API request to main thread.");
     }
     (rx.recv().await).map_or_else(
@@ -784,7 +800,7 @@ async fn get_masterbase_broadcasts(State(state): State<WebState>) -> impl IntoRe
 
 // Check for updates
 
-pub const MAC_VERSION: &str  = "v0.2.0";
+pub const MAC_VERSION: &str = "v0.2.0";
 pub const UPDATE_REPO: &str = "MegaAntiCheat/client-backend";
 
 #[derive(Serialize, Debug)]

--- a/src/web.rs
+++ b/src/web.rs
@@ -788,6 +788,7 @@ pub const MAC_VERSION: &str  = "v0.2.0";
 pub const UPDATE_REPO: &str = "MegaAntiCheat/client-backend";
 
 #[derive(Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
 struct UserVersionResponse {
     current_version: String,
     latest_version: String,

--- a/src/web.rs
+++ b/src/web.rs
@@ -28,7 +28,7 @@ use tokio_stream::wrappers::ReceiverStream;
 
 use super::command_manager::Command;
 use crate::{
-    events::{InternalPreferences, Preferences, UserUpdate, UserUpdates}, masterbase::MasterbaseBroadcastResponse, player::{serialize_steamid_as_string, Friend, FriendInfo, Player, Players, SteamInfo}, server::Gamemode, state::MACState, steam_api::{request_steam_info, ProfileLookupResult}
+    events::{InternalPreferences, Preferences, UserUpdate, UserUpdates}, masterbase::{MasterbaseBroadcastLookup, MasterbaseBroadcastResponse}, player::{Friend, FriendInfo, Player, Players, SteamInfo, serialize_steamid_as_string}, server::Gamemode, state::MACState, steam_api::{request_steam_info, ProfileLookupResult}
 };
 const HEADERS: [(header::HeaderName, &str); 2] = [
     (header::CONTENT_TYPE, "application/json"),
@@ -56,7 +56,7 @@ pub enum WebRequest {
     PostCommand(RequestedCommands),
     GetChat(UnboundedSender<String>),
     GetKillfeed(UnboundedSender<String>),
-    GetMasterbaseStatus(UnboundedSender<String>), // TODO: swap with actual json-serializable type
+    GetMasterbaseBroadcasts(UnboundedSender<String>), // TODO: swap with actual json-serializable type
 }
 impl<S> event_loop::Message<S> for WebRequest {}
 
@@ -75,8 +75,8 @@ pub struct WebAPIHandler {
 
 impl<IM, OM> MessageHandler<MACState, IM, OM> for WebAPIHandler
 where
-    IM: Is<WebRequest> + Is<ProfileLookupResult>,
-    OM: Is<Command> + Is<Preferences> + Is<UserUpdates> + Is<ProfileLookupResult>,
+    IM: Is<WebRequest> + Is<ProfileLookupResult> + Is<MasterbaseBroadcastResponse>,
+    OM: Is<Command> + Is<Preferences> + Is<UserUpdates> + Is<ProfileLookupResult> + Is<MasterbaseBroadcastLookup>,
 {
     #[allow(clippy::cognitive_complexity)]
     fn handle_message(
@@ -92,6 +92,10 @@ where
 
         if let Some(lookup_result) = try_get::<ProfileLookupResult>(message) {
             self.handle_profile_lookup(state, lookup_result);
+        }
+
+        if let Some(masterbase_broadcasts) = try_get::<MasterbaseBroadcastResponse>(message) {
+            self.set_masterbase_broadcasts_response(masterbase_broadcasts);
         }
 
         match try_get::<WebRequest>(message)? {
@@ -127,8 +131,8 @@ where
             WebRequest::GetKillfeed(tx) => {
                 send(tx, get_killfeed_response(state));
             }
-            WebRequest::GetMasterbaseStatus(tx) => {
-                self.handle_masterbase_status_request(tx.clone());
+            WebRequest::GetMasterbaseBroadcasts(tx) => {
+                return self.get_masterbase_broadcasts_response(tx.clone());
             }
         }
 
@@ -278,17 +282,23 @@ impl WebAPIHandler {
 
     // Masterbase status
 
-    fn handle_masterbase_status_request(&mut self, req: UnboundedSender<String>) {
+    fn get_masterbase_broadcasts_response<OM: Is<MasterbaseBroadcastLookup>>(&mut self, req: UnboundedSender<String>) -> Option<Handled<OM>> {
         if let Some(cache) = &self.masterbase_status_cache {
             if cache.latest_update + Duration::seconds(60) > Utc::now() {
                 req.send(serde_json::to_string(&cache).expect("Epic serialization fail")).ok();
-                return;
+                return Handled::none();
             } else {
                 self.masterbase_status_cache = None;
             }
-        } else if self.masterbase_status_cache.is_none() {
-            req.send(StatusCode::NO_CONTENT.to_string()).ok();
         }
+        if self.masterbase_status_cache.is_none() {
+            return Handled::single(MasterbaseBroadcastLookup)
+        }
+        Handled::none()
+    }
+
+    fn set_masterbase_broadcasts_response(&mut self, result: &MasterbaseBroadcastResponse) {
+        self.masterbase_status_cache = Some(result.clone());
     }
 }
 
@@ -745,7 +755,7 @@ fn get_killfeed_response(state: &MACState) -> String {
 async fn get_masterbase_broadcasts(State(state): State<WebState>) -> impl IntoResponse {
     tracing::debug!("API: GET Masterbase broadcasts");
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-    if state.request.send(WebRequest::GetMasterbaseStatus(tx)).is_err() {
+    if state.request.send(WebRequest::GetMasterbaseBroadcasts(tx)).is_err() {
         tracing::error!("Couldn't send API request to main thread.");
     }
     (rx.recv().await).map_or_else(

--- a/src/web.rs
+++ b/src/web.rs
@@ -825,14 +825,14 @@ async fn get_version(State(state): State<WebState>) -> impl IntoResponse {
 
 fn get_version_response(message: &GitHubVersionResponse) -> String {
     let current_version = MAC_VERSION.to_string();
-    let latest_version = message.latest_version.to_owned();
+    let latest_version = message.latest_version.clone();
     let response: UserVersionResponse = UserVersionResponse {
         notify: &latest_version > &current_version,
         current_version,
         latest_version,
     };
     tracing::debug!("Version info: {:?}", &response);
-    return serde_json::to_string(&response).expect("Epic serialization fail");
+    serde_json::to_string(&response).expect("Epic serialization fail")
 }
 
 // Commands

--- a/src/web.rs
+++ b/src/web.rs
@@ -32,7 +32,7 @@ use crate::{
         GitHubVersionLookup, GitHubVersionResponse, InternalPreferences, Preferences, UserUpdate,
         UserUpdates,
     },
-    masterbase::{MasterbaseBroadcastLookup, MasterbaseBroadcastResponse},
+    masterbase::{BroadcastLookup, BroadcastResponse},
     player::{serialize_steamid_as_string, Friend, FriendInfo, Player, Players, SteamInfo},
     server::Gamemode,
     state::MACState,
@@ -79,20 +79,20 @@ struct PostUserRequest {
 pub struct WebAPIHandler {
     profile_requests_in_progress: Vec<SteamID>,
     post_user_queue: Vec<PostUserRequest>,
-    masterbase_status_cache: Option<MasterbaseBroadcastResponse>,
+    masterbase_status_cache: Option<BroadcastResponse>,
 }
 
 impl<IM, OM> MessageHandler<MACState, IM, OM> for WebAPIHandler
 where
     IM: Is<WebRequest>
         + Is<ProfileLookupResult>
-        + Is<MasterbaseBroadcastResponse>
+        + Is<BroadcastResponse>
         + Is<GitHubVersionResponse>,
     OM: Is<Command>
         + Is<Preferences>
         + Is<UserUpdates>
         + Is<ProfileLookupResult>
-        + Is<MasterbaseBroadcastLookup>
+        + Is<BroadcastLookup>
         + Is<GitHubVersionLookup>,
 {
     #[allow(clippy::cognitive_complexity)]
@@ -111,7 +111,7 @@ where
             self.handle_profile_lookup(state, lookup_result);
         }
 
-        if let Some(masterbase_broadcasts) = try_get::<MasterbaseBroadcastResponse>(message) {
+        if let Some(masterbase_broadcasts) = try_get::<BroadcastResponse>(message) {
             self.set_masterbase_broadcasts_response(masterbase_broadcasts);
         }
 
@@ -154,7 +154,7 @@ where
                 send(tx, get_killfeed_response(state));
             }
             WebRequest::GetMasterbaseBroadcasts(tx) => {
-                return self.get_masterbase_broadcasts_response(tx.clone());
+                return self.get_masterbase_broadcasts_response(tx);
             }
             WebRequest::GetVersion(tx) => {
                 return Handled::single(OM::from(GitHubVersionLookup { tx: tx.clone() }));
@@ -307,26 +307,25 @@ impl WebAPIHandler {
 
     // Masterbase status
 
-    fn get_masterbase_broadcasts_response<OM: Is<MasterbaseBroadcastLookup>>(
+    fn get_masterbase_broadcasts_response<OM: Is<BroadcastLookup>>(
         &mut self,
-        req: UnboundedSender<String>,
+        req: &UnboundedSender<String>,
     ) -> Option<Handled<OM>> {
         if let Some(cache) = &self.masterbase_status_cache {
             if cache.latest_update + Duration::seconds(60) > Utc::now() {
                 req.send(serde_json::to_string(&cache).expect("Epic serialization fail"))
                     .ok();
                 return Handled::none();
-            } else {
-                self.masterbase_status_cache = None;
             }
+            self.masterbase_status_cache = None;
         }
         if self.masterbase_status_cache.is_none() {
-            return Handled::single(MasterbaseBroadcastLookup);
+            return Handled::single(BroadcastLookup);
         }
         Handled::none()
     }
 
-    fn set_masterbase_broadcasts_response(&mut self, result: &MasterbaseBroadcastResponse) {
+    fn set_masterbase_broadcasts_response(&mut self, result: &BroadcastResponse) {
         self.masterbase_status_cache = Some(result.clone());
     }
 }
@@ -827,7 +826,7 @@ fn get_version_response(message: &GitHubVersionResponse) -> String {
     let current_version = MAC_VERSION.to_string();
     let latest_version = message.latest_version.clone();
     let response: UserVersionResponse = UserVersionResponse {
-        notify: &latest_version > &current_version,
+        notify: latest_version > current_version,
         current_version,
         latest_version,
     };

--- a/src/web.rs
+++ b/src/web.rs
@@ -13,7 +13,7 @@ use axum::{
     routing::{get, post, put},
     Json, Router,
 };
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Duration, Utc};
 use event_loop::{try_get, Handled, Is, MessageHandler};
 use futures::Stream;
 use include_dir::Dir;
@@ -28,11 +28,7 @@ use tokio_stream::wrappers::ReceiverStream;
 
 use super::command_manager::Command;
 use crate::{
-    events::{InternalPreferences, Preferences, UserUpdate, UserUpdates},
-    player::{serialize_steamid_as_string, Friend, FriendInfo, Player, Players, SteamInfo},
-    server::Gamemode,
-    state::MACState,
-    steam_api::{request_steam_info, ProfileLookupResult},
+    events::{InternalPreferences, Preferences, UserUpdate, UserUpdates}, masterbase::MasterbaseBroadcastResponse, player::{serialize_steamid_as_string, Friend, FriendInfo, Player, Players, SteamInfo}, server::Gamemode, state::MACState, steam_api::{request_steam_info, ProfileLookupResult}
 };
 const HEADERS: [(header::HeaderName, &str); 2] = [
     (header::CONTENT_TYPE, "application/json"),
@@ -60,6 +56,7 @@ pub enum WebRequest {
     PostCommand(RequestedCommands),
     GetChat(UnboundedSender<String>),
     GetKillfeed(UnboundedSender<String>),
+    GetMasterbaseStatus(UnboundedSender<String>), // TODO: swap with actual json-serializable type
 }
 impl<S> event_loop::Message<S> for WebRequest {}
 
@@ -73,6 +70,7 @@ struct PostUserRequest {
 pub struct WebAPIHandler {
     profile_requests_in_progress: Vec<SteamID>,
     post_user_queue: Vec<PostUserRequest>,
+    masterbase_status_cache: Option<MasterbaseBroadcastResponse>,
 }
 
 impl<IM, OM> MessageHandler<MACState, IM, OM> for WebAPIHandler
@@ -129,6 +127,9 @@ where
             WebRequest::GetKillfeed(tx) => {
                 send(tx, get_killfeed_response(state));
             }
+            WebRequest::GetMasterbaseStatus(tx) => {
+                self.handle_masterbase_status_request(tx.clone());
+            }
         }
 
         Handled::none()
@@ -141,8 +142,11 @@ impl WebAPIHandler {
         Self {
             profile_requests_in_progress: Vec::new(),
             post_user_queue: Vec::new(),
+            masterbase_status_cache: None,
         }
     }
+
+    // POST user
 
     fn handle_post_user_request<OM: Is<ProfileLookupResult>>(
         &mut self,
@@ -271,6 +275,21 @@ impl WebAPIHandler {
         self.post_user_queue
             .retain(|req| !req.waiting_users.is_empty());
     }
+
+    // Masterbase status
+
+    fn handle_masterbase_status_request(&mut self, req: UnboundedSender<String>) {
+        if let Some(cache) = &self.masterbase_status_cache {
+            if cache.latest_update + Duration::seconds(60) > Utc::now() {
+                req.send(serde_json::to_string(&cache).expect("Epic serialization fail")).ok();
+                return;
+            } else {
+                self.masterbase_status_cache = None;
+            }
+        } else if self.masterbase_status_cache.is_none() {
+            req.send(StatusCode::NO_CONTENT.to_string()).ok();
+        }
+    }
 }
 
 impl Default for WebAPIHandler {
@@ -321,6 +340,7 @@ pub async fn web_main(web_state: WebState, port: u16) {
         .route("/mac/commands/v1", post(post_commands))
         .route("/mac/chat/v1", get(get_chat))
         .route("/mac/killfeed/v1", get(get_killfeed))
+        .route("/mac/broadcasts/v1", get(get_masterbase_broadcasts))
         .layer(tower_http::cors::CorsLayer::permissive())
         .with_state(web_state);
 
@@ -718,6 +738,20 @@ async fn get_killfeed(State(state): State<WebState>) -> impl IntoResponse {
 
 fn get_killfeed_response(state: &MACState) -> String {
     serde_json::to_string(state.server.kill_history()).expect("Epic serialization fail")
+}
+
+// Masterbase status
+
+async fn get_masterbase_broadcasts(State(state): State<WebState>) -> impl IntoResponse {
+    tracing::debug!("API: GET Masterbase broadcasts");
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    if state.request.send(WebRequest::GetMasterbaseStatus(tx)).is_err() {
+        tracing::error!("Couldn't send API request to main thread.");
+    }
+    (rx.recv().await).map_or_else(
+        || (StatusCode::SERVICE_UNAVAILABLE, HEADERS, String::new()),
+        |resp| (StatusCode::OK, HEADERS, resp),
+    )
 }
 
 // Commands

--- a/src/web.rs
+++ b/src/web.rs
@@ -28,7 +28,7 @@ use tokio_stream::wrappers::ReceiverStream;
 
 use super::command_manager::Command;
 use crate::{
-    events::{InternalPreferences, Preferences, UserUpdate, UserUpdates}, masterbase::{MasterbaseBroadcastLookup, MasterbaseBroadcastResponse}, player::{Friend, FriendInfo, Player, Players, SteamInfo, serialize_steamid_as_string}, server::Gamemode, state::MACState, steam_api::{request_steam_info, ProfileLookupResult}
+    events::{GitHubVersionLookup, GitHubVersionResponse, InternalPreferences, Preferences, UserUpdate, UserUpdates}, masterbase::{MasterbaseBroadcastLookup, MasterbaseBroadcastResponse}, player::{serialize_steamid_as_string, Friend, FriendInfo, Player, Players, SteamInfo}, server::Gamemode, state::MACState, steam_api::{request_steam_info, ProfileLookupResult}
 };
 const HEADERS: [(header::HeaderName, &str); 2] = [
     (header::CONTENT_TYPE, "application/json"),
@@ -56,7 +56,8 @@ pub enum WebRequest {
     PostCommand(RequestedCommands),
     GetChat(UnboundedSender<String>),
     GetKillfeed(UnboundedSender<String>),
-    GetMasterbaseBroadcasts(UnboundedSender<String>), // TODO: swap with actual json-serializable type
+    GetMasterbaseBroadcasts(UnboundedSender<String>),
+    GetVersion(UnboundedSender<String>),
 }
 impl<S> event_loop::Message<S> for WebRequest {}
 
@@ -75,8 +76,16 @@ pub struct WebAPIHandler {
 
 impl<IM, OM> MessageHandler<MACState, IM, OM> for WebAPIHandler
 where
-    IM: Is<WebRequest> + Is<ProfileLookupResult> + Is<MasterbaseBroadcastResponse>,
-    OM: Is<Command> + Is<Preferences> + Is<UserUpdates> + Is<ProfileLookupResult> + Is<MasterbaseBroadcastLookup>,
+    IM: Is<WebRequest> +
+        Is<ProfileLookupResult> +
+        Is<MasterbaseBroadcastResponse> +
+        Is<GitHubVersionResponse>,
+    OM: Is<Command> +
+        Is<Preferences> +
+        Is<UserUpdates> +
+        Is<ProfileLookupResult> +
+        Is<MasterbaseBroadcastLookup> +
+        Is<GitHubVersionLookup>,
 {
     #[allow(clippy::cognitive_complexity)]
     fn handle_message(
@@ -96,6 +105,11 @@ where
 
         if let Some(masterbase_broadcasts) = try_get::<MasterbaseBroadcastResponse>(message) {
             self.set_masterbase_broadcasts_response(masterbase_broadcasts);
+        }
+
+        if let Some(version_result) = try_get::<GitHubVersionResponse>(message) {
+            tracing::debug!("reply from github reached webhandler");
+            send(&version_result.tx, get_version_response(version_result));
         }
 
         match try_get::<WebRequest>(message)? {
@@ -133,6 +147,9 @@ where
             }
             WebRequest::GetMasterbaseBroadcasts(tx) => {
                 return self.get_masterbase_broadcasts_response(tx.clone());
+            }
+            WebRequest::GetVersion(tx) => {
+                return Handled::single(OM::from(GitHubVersionLookup { tx: tx.clone() }));
             }
         }
 
@@ -351,6 +368,7 @@ pub async fn web_main(web_state: WebState, port: u16) {
         .route("/mac/chat/v1", get(get_chat))
         .route("/mac/killfeed/v1", get(get_killfeed))
         .route("/mac/broadcasts/v1", get(get_masterbase_broadcasts))
+        .route("/mac/version/v1", get(get_version))
         .layer(tower_http::cors::CorsLayer::permissive())
         .with_state(web_state);
 
@@ -762,6 +780,42 @@ async fn get_masterbase_broadcasts(State(state): State<WebState>) -> impl IntoRe
         || (StatusCode::SERVICE_UNAVAILABLE, HEADERS, String::new()),
         |resp| (StatusCode::OK, HEADERS, resp),
     )
+}
+
+// Check for updates
+
+pub const MAC_VERSION: &str  = "v0.2.0";
+pub const UPDATE_REPO: &str = "MegaAntiCheat/client-backend";
+
+#[derive(Serialize, Debug)]
+struct UserVersionResponse {
+    current_version: String,
+    latest_version: String,
+    notify: bool,
+}
+
+async fn get_version(State(state): State<WebState>) -> impl IntoResponse {
+    tracing::debug!("API: GET version");
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    if state.request.send(WebRequest::GetVersion(tx)).is_err() {
+        tracing::error!("Couldn't send API request to main thread.");
+    }
+    (rx.recv().await).map_or_else(
+        || (StatusCode::SERVICE_UNAVAILABLE, HEADERS, String::new()),
+        |resp| (StatusCode::OK, HEADERS, resp),
+    )
+}
+
+fn get_version_response(message: &GitHubVersionResponse) -> String {
+    let current_version = MAC_VERSION.to_string();
+    let latest_version = message.latest_version.to_owned();
+    let response: UserVersionResponse = UserVersionResponse {
+        notify: &latest_version > &current_version,
+        current_version,
+        latest_version,
+    };
+    tracing::debug!("Version info: {:?}", &response);
+    return serde_json::to_string(&response).expect("Epic serialization fail");
 }
 
 // Commands


### PR DESCRIPTION
Depends on https://github.com/MegaAntiCheat/masterbase/pull/94

Late bytes are uploaded through POST /close_session.

Reads broadcasts from GET /broadcasts and caches them. Broadcasts are checked every 15 seconds and are cached for up to 1 minute.

The client can also contacts GitHub to obtain release information, and exposes an endpoint so this info can be served to the UI.

